### PR TITLE
0.11.2 fix wrong deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-03-30
+
+### Fixed
+
+- Fixed `log` feature not enabling `embassy-net/log`, causing compile failures when using the `log` feature.
+- Removed `defmt` from `embassy-net` default features (was accidentally always enabled).
+
 ## [0.11.1] - 2026-03-27
 
 ### Changed
@@ -143,7 +150,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, and CONNECT methods.
 - Configurable client options (retries, timeouts, delays).
 
-[Unreleased]: https://github.com/rttfd/nanofish/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/rttfd/nanofish/compare/v0.11.2...HEAD
+[0.11.2]: https://github.com/rttfd/nanofish/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/rttfd/nanofish/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/rttfd/nanofish/compare/v0.10.0...v0.11.0
 [0.9.1]: https://github.com/rttfd/nanofish/compare/v0.9.0...v0.9.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanofish"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 rust-version = "1.91"
 description = "🐟 A lightweight, `no_std` HTTP client and server for embedded systems built on top of Embassy networking."


### PR DESCRIPTION
 - Fixed log feature not enabling embassy-net/log, causing compile failures when using the log feature
 - Removed defmt from embassy-net default features (was accidentally always enabled)