### PR TITLE
fix: handle binary HTTP responses, bump to v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3] - 2026-04-22
+
+### Fixed
+
+- Fixed requests failing with `Error::InvalidResponse("Invalid HTTP response encoding")` on binary responses (e.g., PNG images). The HTTP response parser now only requires headers to be valid UTF-8, not the entire response body ([#26](https://github.com/rttfd/nanofish/issues/26)).
+
+### Changed
+
+- Bumped `embassy-net` from `0.9.0` to `0.9.1`.
+
 ## [0.11.2] - 2026-03-30
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanofish"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2024"
 rust-version = "1.91"
 description = "🐟 A lightweight, `no_std` HTTP client and server for embedded systems built on top of Embassy networking."
@@ -18,7 +18,7 @@ log = ["dep:log", "embassy-net/log"]
 
 [dependencies]
 defmt = { version = "1.0.1", optional = true }
-embassy-net = { version = "0.9.0", features = [
+embassy-net = { version = "0.9.1", features = [
     "dns",
     "medium-ethernet",
     "proto-ipv6",

--- a/src/client.rs
+++ b/src/client.rs
@@ -652,7 +652,16 @@ impl<
 
     /// Parse HTTP response from raw data with zero-copy handling
     fn parse_http_response_zero_copy(data: &[u8]) -> Result<HttpResponse<'_>, Error> {
-        let response_str = core::str::from_utf8(data)
+        // Find the end of headers delimiter in raw bytes to avoid
+        // requiring the entire response (including binary body) to be valid UTF-8.
+        let headers_end = data
+            .windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .ok_or(Error::InvalidResponse("Invalid HTTP response format"))?
+            + 4;
+
+        let header_bytes = &data[..headers_end];
+        let response_str = core::str::from_utf8(header_bytes)
             .map_err(|_| Error::InvalidResponse("Invalid HTTP response encoding"))?;
 
         let status_line_end = response_str
@@ -666,11 +675,6 @@ impl<
             .ok_or(Error::InvalidResponse("Invalid HTTP status line"))?;
 
         let status_code: StatusCode = status_code_str.try_into()?;
-
-        let headers_end = response_str
-            .find("\r\n\r\n")
-            .ok_or(Error::InvalidResponse("Invalid HTTP response format"))?
-            + 4;
 
         let headers_section = &response_str[status_line_end + 2..headers_end - 4];
         let mut headers = Vec::<HttpHeader<'_>, MAX_HEADERS>::new();
@@ -918,5 +922,33 @@ mod tests {
             },
         );
         assert_eq!(client_small_custom.options.max_retries, 2);
+    }
+
+    #[test]
+    fn test_parse_http_response_binary_body() {
+        // Simulate a PNG-like response with invalid UTF-8 in the body
+        let header = b"HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: 8\r\n\r\n";
+        let binary_body: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]; // PNG magic bytes
+        let mut data = [0u8; 256];
+        data[..header.len()].copy_from_slice(header);
+        data[header.len()..header.len() + binary_body.len()].copy_from_slice(&binary_body);
+        let data = &data[..header.len() + binary_body.len()];
+
+        let response = DefaultHttpClient::parse_http_response_zero_copy(data)
+            .expect("should parse binary response");
+
+        assert_eq!(response.status_code, StatusCode::Ok);
+        assert!(matches!(response.body, ResponseBody::Binary(b) if b == binary_body));
+    }
+
+    #[test]
+    fn test_parse_http_response_text_body() {
+        let data = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello";
+
+        let response = DefaultHttpClient::parse_http_response_zero_copy(data)
+            .expect("should parse text response");
+
+        assert_eq!(response.status_code, StatusCode::Ok);
+        assert!(matches!(response.body, ResponseBody::Text("hello")));
     }
 }


### PR DESCRIPTION
## Summary

- Fix requests failing with `InvalidResponse("Invalid HTTP response encoding")` on binary responses (e.g., PNG images) by parsing only HTTP headers as UTF-8 instead of the entire response buffer. Closes #26.
- Bump `embassy-net` from `0.9.0` to `0.9.1`.
- Bump version to `0.11.3`.