### PR TITLE
v0.11.4rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.4] - 2026-05-18
+
+### Added
+
+- Support for `Transfer-Encoding: chunked` responses. Chunked bodies are decoded in-place before parsing ([#29](https://github.com/rttfd/nanofish/issues/29)).
+
+### Fixed
+
+- Removed unsafe dangling pointer usage from README examples ([#28](https://github.com/rttfd/nanofish/issues/28)).
+
+### Changed
+
+- Bumped `defmt` from `1.0.1` to `1.1.0`.
+- Bumped `heapless` from `0.9.2` to `0.9.3`.
+
 ## [0.11.3] - 2026-04-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for `Transfer-Encoding: chunked` responses. Chunked bodies are decoded in-place before parsing ([#29](https://github.com/rttfd/nanofish/issues/29)).
+- New `protocol` module with shared HTTP constants (`CRLF`, `DOUBLE_CRLF`, `MAX_HEADERS`, `HTTP_VERSION`, port defaults) and utilities (`find_double_crlf`, `find_crlf`, `find_header_value`).
 
 ### Fixed
 
@@ -19,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refactored codebase to eliminate magic numbers and duplicated constants (SOLID/DRY).
+- Consolidated `MAX_HEADERS` into a single definition in `protocol` module (was defined separately in `client.rs`, `request.rs`, and hardcoded in `response.rs`).
+- Replaced scattered `windows(4).position(...)` patterns with shared `protocol::find_double_crlf` and `protocol::find_crlf` utilities.
 - Bumped `defmt` from `1.0.1` to `1.1.0`.
 - Bumped `heapless` from `0.9.2` to `0.9.3`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanofish"
-version = "0.11.3"
+version = "0.11.4"
 edition = "2024"
 rust-version = "1.91"
 description = "🐟 A lightweight, `no_std` HTTP client and server for embedded systems built on top of Embassy networking."
@@ -17,7 +17,7 @@ defmt = ["dep:defmt", "embassy-net/defmt"]
 log = ["dep:log", "embassy-net/log"]
 
 [dependencies]
-defmt = { version = "1.0.1", optional = true }
+defmt = { version = "1.1.0", optional = true }
 embassy-net = { version = "0.9.1", features = [
     "dns",
     "medium-ethernet",
@@ -27,7 +27,7 @@ embassy-net = { version = "0.9.1", features = [
 embassy-time = "0.5.1"
 embedded-io-async = "0.7.0"
 embedded-tls = { version = "0.18.0", default-features = false, optional = true }
-heapless = "0.9.2"
+heapless = "0.9.3"
 log = { version = "0.4", optional = true }
 rand_chacha = { version = "0.3", default-features = false, optional = true }
 rand_core = { version = "0.6.4", optional = true }

--- a/README.md
+++ b/README.md
@@ -31,24 +31,24 @@ Nanofish is designed for embedded systems with limited memory. It provides a sim
 ### Basic HTTP Support (Default)
 ```toml
 [dependencies]
-nanofish = "0.11.1"
+nanofish = "0.11.4"
 ```
 
 ### With TLS/HTTPS Support
 ```toml
 [dependencies]
-nanofish = { version = "0.11.0", features = ["tls"] }
+nanofish = { version = "0.11.4", features = ["tls"] }
 ```
 
 ### With Logging
 ```toml
 # Using defmt (common in embedded/probe-based workflows)
 [dependencies]
-nanofish = { version = "0.11.0", features = ["defmt"] }
+nanofish = { version = "0.11.4", features = ["defmt"] }
 
 # Using the log crate (common in std or defmt-incompatible environments)
 [dependencies]
-nanofish = { version = "0.11.0", features = ["log"] }
+nanofish = { version = "0.11.4", features = ["log"] }
 ```
 
 > **Note:** The `defmt` and `log` features are **mutually exclusive**. Enabling both will produce a compile-time error. If neither is enabled, all logging calls are compiled away to no-ops.
@@ -95,27 +95,25 @@ use nanofish::{DefaultHttpClient, HttpHeader, ResponseBody, headers, mime_types}
 use embassy_net::Stack;
 
 async fn example(stack: &Stack<'_>) -> Result<(), nanofish::Error> {
-    ...
-    // See crate docs for full async usage example
+    let client = DefaultHttpClient::new(stack);
+    let mut response_buffer = [0u8; 8192];
+    let headers = [
+        HttpHeader::user_agent("Nanofish/0.11.4"),
+        HttpHeader::content_type(mime_types::JSON),
+        HttpHeader::authorization("Bearer token123"),
+    ];
+    let custom_headers = [
+        HttpHeader { name: "X-Custom-Header", value: "custom-value" },
+        HttpHeader::new(headers::ACCEPT, mime_types::JSON),
+    ];
+    let (response, bytes_read) = client.get(
+        "http://example.com/api/status",
+        &headers,
+        &mut response_buffer
+    ).await?;
+    println!("Read {} bytes into buffer", bytes_read);
+    Ok(())
 }
-
-let client = DefaultHttpClient::new(unsafe { core::ptr::NonNull::dangling().as_ref() });
-let mut response_buffer = [0u8; 8192];
-let headers = [
-    HttpHeader::user_agent("Nanofish/0.11.1"),
-    HttpHeader::content_type(mime_types::JSON),
-    HttpHeader::authorization("Bearer token123"),
-];
-let custom_headers = [
-    HttpHeader { name: "X-Custom-Header", value: "custom-value" },
-    HttpHeader::new(headers::ACCEPT, mime_types::JSON),
-];
-let (response, bytes_read) = client.get(
-    "http://example.com/api/status", 
-    &headers,
-    &mut response_buffer
-).await?;
-println!("Read {} bytes into buffer", bytes_read);
 ```
 
 ## Zero-Copy Benefits

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,8 +1,15 @@
 use crate::{
     error::Error,
-    header::HttpHeader,
+    header::{
+        HttpHeader,
+        headers::{CONTENT_LENGTH, CONTENT_TYPE},
+    },
     method::HttpMethod,
     options::HttpClientOptions,
+    protocol::{
+        self, CHUNKED, CHUNKED_END_MARKER, CRLF_LEN, DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT,
+        DOUBLE_CRLF_LEN, HTTP_VERSION_LINE_SUFFIX, MAX_HEADERS, MAX_URL_PARTS, TRANSFER_ENCODING,
+    },
     response::{HttpResponse, ResponseBody},
     status_code::StatusCode,
 };
@@ -24,7 +31,6 @@ use rand_chacha::ChaCha8Rng;
 use rand_core::SeedableRng;
 
 const REQUEST_SIZE: usize = 1024;
-const MAX_HEADERS: usize = 16;
 const SMALL_BUFFER_SIZE: usize = 1024;
 const MEDIUM_BUFFER_SIZE: usize = 4096;
 
@@ -182,8 +188,8 @@ impl<
             return Err(Error::InvalidUrl);
         };
 
-        let mut url_parts = heapless::Vec::<&str, 8>::new();
-        for part in host_port.splitn(8, '/') {
+        let mut url_parts = heapless::Vec::<&str, MAX_URL_PARTS>::new();
+        for part in host_port.splitn(MAX_URL_PARTS, '/') {
             if url_parts.push(part).is_err() {
                 break;
             }
@@ -195,14 +201,19 @@ impl<
         let host = url_parts[0];
         let path = &host_port[host.len()..];
 
+        let default_port = if scheme == "https" {
+            DEFAULT_HTTPS_PORT
+        } else {
+            DEFAULT_HTTP_PORT
+        };
         let (host, port) = if let Some(colon_pos) = host.rfind(':') {
             if let Ok(port) = host[colon_pos + 1..].parse::<u16>() {
                 (&host[..colon_pos], port)
             } else {
-                (host, if scheme == "https" { 443 } else { 80 })
+                (host, default_port)
             }
         } else {
-            (host, if scheme == "https" { 443 } else { 80 })
+            (host, default_port)
         };
 
         let total_read = match scheme {
@@ -657,18 +668,15 @@ impl<
     fn parse_http_response_zero_copy(data: &[u8]) -> Result<HttpResponse<'_>, Error> {
         // Find the end of headers delimiter in raw bytes to avoid
         // requiring the entire response (including binary body) to be valid UTF-8.
-        let headers_end = data
-            .windows(4)
-            .position(|w| w == b"\r\n\r\n")
+        let headers_end = protocol::find_double_crlf(data)
             .ok_or(Error::InvalidResponse("Invalid HTTP response format"))?
-            + 4;
+            + DOUBLE_CRLF_LEN;
 
         let header_bytes = &data[..headers_end];
         let response_str = core::str::from_utf8(header_bytes)
             .map_err(|_| Error::InvalidResponse("Invalid HTTP response encoding"))?;
 
-        let status_line_end = response_str
-            .find("\r\n")
+        let status_line_end = protocol::find_crlf(header_bytes)
             .ok_or(Error::InvalidResponse("Invalid HTTP response format"))?;
 
         let status_line = &response_str[..status_line_end];
@@ -679,7 +687,8 @@ impl<
 
         let status_code: StatusCode = status_code_str.try_into()?;
 
-        let headers_section = &response_str[status_line_end + 2..headers_end - 4];
+        let headers_section =
+            &response_str[status_line_end + CRLF_LEN..headers_end - DOUBLE_CRLF_LEN];
         let mut headers = Vec::<HttpHeader<'_>, MAX_HEADERS>::new();
 
         for header_line in headers_section.split("\r\n") {
@@ -736,7 +745,7 @@ impl<
     fn get_content_type<'h>(headers: &'h [HttpHeader<'_>]) -> Option<&'h str> {
         headers
             .iter()
-            .find(|h| h.name.eq_ignore_ascii_case("Content-Type"))
+            .find(|h| h.name.eq_ignore_ascii_case(CONTENT_TYPE))
             .map(|h| h.value)
     }
 
@@ -775,7 +784,7 @@ impl<
         try_push!(http_request.push_str(method.as_str()));
         try_push!(http_request.push_str(" "));
         try_push!(http_request.push_str(path));
-        try_push!(http_request.push_str(" HTTP/1.1\r\n"));
+        try_push!(http_request.push_str(HTTP_VERSION_LINE_SUFFIX));
         try_push!(http_request.push_str("Host: "));
         try_push!(http_request.push_str(host));
         try_push!(http_request.push_str("\r\n"));
@@ -788,7 +797,7 @@ impl<
             try_push!(http_request.push_str(header.value));
             try_push!(http_request.push_str("\r\n"));
 
-            if header.name.eq_ignore_ascii_case("Content-Length") {
+            if header.name.eq_ignore_ascii_case(CONTENT_LENGTH) {
                 content_length_present = true;
             }
         }
@@ -809,40 +818,36 @@ impl<
             try_push!(http_request.push_str("\r\n"));
         }
 
-        try_push!(http_request.push_str("Connection: close\r\n"));
-        try_push!(http_request.push_str("\r\n"));
+        try_push!(http_request.push_str("Connection: close\r\n\r\n"));
 
         Ok(http_request)
     }
 
     /// Check if HTTP response is complete
     fn is_response_complete(data: &[u8]) -> bool {
-        let response_str = core::str::from_utf8(data).unwrap_or_default();
-
-        if !response_str.contains("\r\n\r\n") {
+        if protocol::find_double_crlf(data).is_none() {
             return false;
         }
 
         // Check for chunked transfer encoding
         if Self::has_chunked_transfer_encoding(data) {
-            // Chunked responses end with "0\r\n\r\n" (final chunk)
-            return data.windows(5).any(|w| w == b"0\r\n\r\n");
+            return data
+                .windows(CHUNKED_END_MARKER.len())
+                .any(|w| w == CHUNKED_END_MARKER);
         }
 
         // Check for Content-Length header to determine if we have the full body
-        if let Some(content_length_pos) = response_str.find("Content-Length:") {
-            let content_length_end = response_str[content_length_pos..]
-                .find("\r\n")
-                .unwrap_or_default()
-                + content_length_pos;
-            let content_length_str =
-                &response_str[content_length_pos + 15..content_length_end].trim();
-
-            if let Ok(content_length) = content_length_str.parse::<usize>() {
-                let headers_end = response_str.find("\r\n\r\n").unwrap_or_default() + 4;
-                let body_received = data.len().saturating_sub(headers_end);
-                return body_received >= content_length;
-            }
+        let headers_end = match protocol::find_double_crlf(data) {
+            Some(pos) => pos + DOUBLE_CRLF_LEN,
+            None => return true,
+        };
+        let header_bytes = &data[..headers_end];
+        if let Ok(headers_str) = core::str::from_utf8(header_bytes)
+            && let Some(value) = protocol::find_header_value(headers_str, CONTENT_LENGTH)
+            && let Ok(content_length) = value.parse::<usize>()
+        {
+            let body_received = data.len().saturating_sub(headers_end);
+            return body_received >= content_length;
         }
 
         true
@@ -850,27 +855,16 @@ impl<
 
     /// Check if the response uses chunked transfer encoding
     fn has_chunked_transfer_encoding(data: &[u8]) -> bool {
-        // Find end of headers
-        let headers_end = match data.windows(4).position(|w| w == b"\r\n\r\n") {
-            Some(pos) => pos + 4,
+        let headers_end = match protocol::find_double_crlf(data) {
+            Some(pos) => pos + DOUBLE_CRLF_LEN,
             None => return false,
         };
 
-        // Only look at headers portion
         let header_bytes = &data[..headers_end];
-        if let Ok(headers_str) = core::str::from_utf8(header_bytes) {
-            // Case-insensitive search for Transfer-Encoding: chunked
-            for line in headers_str.split("\r\n") {
-                if let Some(colon_pos) = line.find(':') {
-                    let name = line[..colon_pos].trim();
-                    let value = line[colon_pos + 1..].trim();
-                    if name.eq_ignore_ascii_case("Transfer-Encoding")
-                        && value.eq_ignore_ascii_case("chunked")
-                    {
-                        return true;
-                    }
-                }
-            }
+        if let Ok(headers_str) = core::str::from_utf8(header_bytes)
+            && let Some(value) = protocol::find_header_value(headers_str, TRANSFER_ENCODING)
+        {
+            return value.eq_ignore_ascii_case(CHUNKED);
         }
         false
     }
@@ -885,11 +879,9 @@ impl<
         }
 
         // Find end of headers
-        let headers_end = data
-            .windows(4)
-            .position(|w| w == b"\r\n\r\n")
+        let headers_end = protocol::find_double_crlf(data)
             .ok_or(Error::InvalidResponse("Invalid HTTP response format"))?
-            + 4;
+            + DOUBLE_CRLF_LEN;
 
         // Decode chunks in-place starting after headers
         let mut read_pos = headers_end;
@@ -897,10 +889,7 @@ impl<
 
         while read_pos < total_read {
             // Find end of chunk size line
-            let chunk_line_end = match buffer[read_pos..total_read]
-                .windows(2)
-                .position(|w| w == b"\r\n")
-            {
+            let chunk_line_end = match protocol::find_crlf(&buffer[read_pos..total_read]) {
                 Some(pos) => read_pos + pos,
                 None => break,
             };
@@ -922,7 +911,7 @@ impl<
             }
 
             // Move past chunk size line (\r\n)
-            let chunk_data_start = chunk_line_end + 2;
+            let chunk_data_start = chunk_line_end + CRLF_LEN;
             let chunk_data_end = chunk_data_start + chunk_size;
 
             if chunk_data_end > total_read {
@@ -936,7 +925,7 @@ impl<
             write_pos += chunk_size;
 
             // Skip past chunk data and trailing \r\n
-            read_pos = chunk_data_end + 2;
+            read_pos = chunk_data_end + CRLF_LEN;
         }
 
         Ok(write_pos)

--- a/src/client.rs
+++ b/src/client.rs
@@ -220,6 +220,9 @@ impl<
             _ => return Err(Error::UnsupportedScheme(scheme)),
         };
 
+        // Decode chunked transfer-encoding in-place if present
+        let total_read = Self::dechunk(response_buffer, total_read)?;
+
         let response = Self::parse_http_response_zero_copy(&response_buffer[..total_read])?;
         Ok((response, total_read))
     }
@@ -820,6 +823,12 @@ impl<
             return false;
         }
 
+        // Check for chunked transfer encoding
+        if Self::has_chunked_transfer_encoding(data) {
+            // Chunked responses end with "0\r\n\r\n" (final chunk)
+            return data.windows(5).any(|w| w == b"0\r\n\r\n");
+        }
+
         // Check for Content-Length header to determine if we have the full body
         if let Some(content_length_pos) = response_str.find("Content-Length:") {
             let content_length_end = response_str[content_length_pos..]
@@ -837,6 +846,100 @@ impl<
         }
 
         true
+    }
+
+    /// Check if the response uses chunked transfer encoding
+    fn has_chunked_transfer_encoding(data: &[u8]) -> bool {
+        // Find end of headers
+        let headers_end = match data.windows(4).position(|w| w == b"\r\n\r\n") {
+            Some(pos) => pos + 4,
+            None => return false,
+        };
+
+        // Only look at headers portion
+        let header_bytes = &data[..headers_end];
+        if let Ok(headers_str) = core::str::from_utf8(header_bytes) {
+            // Case-insensitive search for Transfer-Encoding: chunked
+            for line in headers_str.split("\r\n") {
+                if let Some(colon_pos) = line.find(':') {
+                    let name = line[..colon_pos].trim();
+                    let value = line[colon_pos + 1..].trim();
+                    if name.eq_ignore_ascii_case("Transfer-Encoding")
+                        && value.eq_ignore_ascii_case("chunked")
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Decode chunked transfer-encoding in-place if the response uses it.
+    /// Returns the new total length after decoding.
+    fn dechunk(buffer: &mut [u8], total_read: usize) -> Result<usize, Error> {
+        let data = &buffer[..total_read];
+
+        if !Self::has_chunked_transfer_encoding(data) {
+            return Ok(total_read);
+        }
+
+        // Find end of headers
+        let headers_end = data
+            .windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .ok_or(Error::InvalidResponse("Invalid HTTP response format"))?
+            + 4;
+
+        // Decode chunks in-place starting after headers
+        let mut read_pos = headers_end;
+        let mut write_pos = headers_end;
+
+        while read_pos < total_read {
+            // Find end of chunk size line
+            let chunk_line_end = match buffer[read_pos..total_read]
+                .windows(2)
+                .position(|w| w == b"\r\n")
+            {
+                Some(pos) => read_pos + pos,
+                None => break,
+            };
+
+            // Parse chunk size (hex)
+            let chunk_size_str = match core::str::from_utf8(&buffer[read_pos..chunk_line_end]) {
+                Ok(s) => s.trim(),
+                Err(_) => return Err(Error::InvalidResponse("Invalid chunk size encoding")),
+            };
+
+            // Chunk size may have extensions after a semicolon
+            let size_part = chunk_size_str.split(';').next().unwrap_or("0").trim();
+            let chunk_size = usize::from_str_radix(size_part, 16)
+                .map_err(|_| Error::InvalidResponse("Invalid chunk size"))?;
+
+            if chunk_size == 0 {
+                // Final chunk
+                break;
+            }
+
+            // Move past chunk size line (\r\n)
+            let chunk_data_start = chunk_line_end + 2;
+            let chunk_data_end = chunk_data_start + chunk_size;
+
+            if chunk_data_end > total_read {
+                return Err(Error::InvalidResponse("Incomplete chunked body"));
+            }
+
+            // Copy chunk data in-place (memmove semantics)
+            if write_pos != chunk_data_start {
+                buffer.copy_within(chunk_data_start..chunk_data_end, write_pos);
+            }
+            write_pos += chunk_size;
+
+            // Skip past chunk data and trailing \r\n
+            read_pos = chunk_data_end + 2;
+        }
+
+        Ok(write_pos)
     }
 }
 
@@ -950,5 +1053,57 @@ mod tests {
 
         assert_eq!(response.status_code, StatusCode::Ok);
         assert!(matches!(response.body, ResponseBody::Text("hello")));
+    }
+
+    #[test]
+    fn test_is_response_complete_chunked() {
+        let incomplete = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n";
+        assert!(!DefaultHttpClient::is_response_complete(incomplete));
+
+        let complete =
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
+        assert!(DefaultHttpClient::is_response_complete(complete));
+    }
+
+    #[test]
+    fn test_dechunk_single_chunk() {
+        let raw = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
+        let mut buf = [0u8; 256];
+        buf[..raw.len()].copy_from_slice(raw);
+
+        let new_len =
+            DefaultHttpClient::dechunk(&mut buf, raw.len()).expect("should decode chunked");
+
+        let response = DefaultHttpClient::parse_http_response_zero_copy(&buf[..new_len])
+            .expect("should parse dechunked response");
+
+        assert_eq!(response.status_code, StatusCode::Ok);
+        assert_eq!(response.body.as_str(), Some("hello"));
+    }
+
+    #[test]
+    fn test_dechunk_multiple_chunks() {
+        // Mimics the weather API response from issue #29
+        let raw = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Type: application/json\r\n\r\nb\r\n{\"temp\":23}\r\n0\r\n\r\n";
+        let mut buf = [0u8; 256];
+        buf[..raw.len()].copy_from_slice(raw);
+
+        let new_len =
+            DefaultHttpClient::dechunk(&mut buf, raw.len()).expect("should decode chunked");
+
+        let response = DefaultHttpClient::parse_http_response_zero_copy(&buf[..new_len])
+            .expect("should parse dechunked response");
+
+        assert_eq!(response.body.as_str(), Some("{\"temp\":23}"));
+    }
+
+    #[test]
+    fn test_dechunk_noop_when_not_chunked() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello";
+        let mut buf = [0u8; 128];
+        buf[..raw.len()].copy_from_slice(raw);
+
+        let new_len = DefaultHttpClient::dechunk(&mut buf, raw.len()).expect("should pass through");
+        assert_eq!(new_len, raw.len());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@
 /// Logging macros
 pub(crate) mod fmt;
 
+/// HTTP protocol constants and shared utilities.
+pub mod protocol;
+
 /// HTTP client implementation and request logic.
 pub mod client;
 /// Error types for HTTP operations.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,0 +1,69 @@
+//! HTTP protocol constants and shared utilities.
+
+/// Carriage Return + Line Feed
+pub const CRLF: &[u8] = b"\r\n";
+
+/// Length of CRLF
+pub const CRLF_LEN: usize = CRLF.len();
+
+/// Double CRLF — separates HTTP headers from body
+pub const DOUBLE_CRLF: &[u8] = b"\r\n\r\n";
+
+/// Length of double CRLF
+pub const DOUBLE_CRLF_LEN: usize = DOUBLE_CRLF.len();
+
+/// Chunked transfer encoding final chunk marker
+pub const CHUNKED_END_MARKER: &[u8] = b"0\r\n\r\n";
+
+/// HTTP/1.1 version string
+pub const HTTP_VERSION: &str = "HTTP/1.1";
+
+/// HTTP/1.1 version as bytes with leading space and trailing CRLF (for request line)
+pub const HTTP_VERSION_LINE_SUFFIX: &str = " HTTP/1.1\r\n";
+
+/// Default HTTP port
+pub const DEFAULT_HTTP_PORT: u16 = 80;
+
+/// Default HTTPS port
+pub const DEFAULT_HTTPS_PORT: u16 = 443;
+
+/// Transfer-Encoding header name
+pub const TRANSFER_ENCODING: &str = "Transfer-Encoding";
+
+/// Chunked transfer encoding value
+pub const CHUNKED: &str = "chunked";
+
+/// Maximum number of headers allowed in requests and responses
+pub const MAX_HEADERS: usize = 16;
+
+/// Maximum URL path segments
+pub const MAX_URL_PARTS: usize = 8;
+
+/// Find the position of the double CRLF sequence in raw bytes.
+/// Returns the byte index of the start of `\r\n\r\n`.
+#[must_use]
+pub fn find_double_crlf(data: &[u8]) -> Option<usize> {
+    data.windows(DOUBLE_CRLF_LEN).position(|w| w == DOUBLE_CRLF)
+}
+
+/// Find the position of CRLF in raw bytes starting from a given slice.
+/// Returns the byte index relative to the start of the provided slice.
+#[must_use]
+pub fn find_crlf(data: &[u8]) -> Option<usize> {
+    data.windows(CRLF_LEN).position(|w| w == CRLF)
+}
+
+/// Check if a header name matches (case-insensitive) and return its value.
+#[must_use]
+pub fn find_header_value<'a>(headers_str: &'a str, target_name: &str) -> Option<&'a str> {
+    for line in headers_str.split("\r\n") {
+        if let Some(colon_pos) = line.find(':') {
+            let name = line[..colon_pos].trim();
+            let value = line[colon_pos + 1..].trim();
+            if name.eq_ignore_ascii_case(target_name) {
+                return Some(value);
+            }
+        }
+    }
+    None
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,8 +1,10 @@
-use crate::{error::Error, header::HttpHeader, method::HttpMethod};
+use crate::{
+    error::Error,
+    header::HttpHeader,
+    method::HttpMethod,
+    protocol::{self, DOUBLE_CRLF_LEN, MAX_HEADERS},
+};
 use heapless::Vec;
-
-/// Maximum number of headers allowed in a request
-pub const MAX_HEADERS: usize = 16;
 
 /// HTTP request parsed from client
 #[derive(Debug)]
@@ -17,12 +19,6 @@ pub struct HttpRequest<'a> {
     pub headers: Vec<HttpHeader<'a>, MAX_HEADERS>,
     /// Request body (if present)
     pub body: &'a [u8],
-}
-
-/// Find the position of the double CRLF sequence that separates headers from body
-fn find_double_crlf(data: &[u8]) -> Option<usize> {
-    const DOUBLE_CRLF: &[u8] = b"\r\n\r\n";
-    (0..data.len().saturating_sub(3)).find(|&i| &data[i..i + 4] == DOUBLE_CRLF)
 }
 
 impl<'a> HttpRequest<'a> {
@@ -88,15 +84,15 @@ impl<'a> TryFrom<&'a [u8]> for HttpRequest<'a> {
 
     fn try_from(buffer: &'a [u8]) -> Result<Self, Self::Error> {
         // Find the end of headers (double CRLF)
-        let end_of_headers =
-            find_double_crlf(buffer).ok_or(Error::InvalidResponse("Incomplete request headers"))?;
+        let end_of_headers = protocol::find_double_crlf(buffer)
+            .ok_or(Error::InvalidResponse("Incomplete request headers"))?;
 
         // Parse the headers string
         let headers_str = core::str::from_utf8(&buffer[..end_of_headers])
             .map_err(|_| Error::InvalidResponse("Invalid UTF-8 in request"))?;
 
         // Body starts after the double CRLF
-        let body = &buffer[end_of_headers + 4..];
+        let body = &buffer[end_of_headers + DOUBLE_CRLF_LEN..];
 
         Self::parse_from(headers_str, body)
     }
@@ -195,6 +191,8 @@ mod tests {
 
     #[test]
     fn test_find_double_crlf() {
+        use crate::protocol::find_double_crlf;
+
         // Normal case
         let data = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\nBody";
         assert_eq!(find_double_crlf(data), Some(33));

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,7 @@
-use crate::{HttpHeader, StatusCode};
+use crate::{
+    HttpHeader, StatusCode,
+    protocol::{CRLF, MAX_HEADERS},
+};
 use heapless::Vec;
 
 /// HTTP Response body that can handle both text and binary data using zero-copy references
@@ -63,7 +66,7 @@ pub struct HttpResponse<'a> {
     /// The HTTP status code (e.g., 200 for OK, 404 for Not Found)
     pub status_code: StatusCode,
     /// A collection of response headers with both names and values
-    pub headers: Vec<HttpHeader<'a>, 16>,
+    pub headers: Vec<HttpHeader<'a>, MAX_HEADERS>,
     /// The response body that can handle both text and binary data
     pub body: ResponseBody<'a>,
 }
@@ -121,7 +124,7 @@ impl HttpResponse<'_> {
             let _ = bytes.extend_from_slice(header.name.as_bytes());
             let _ = bytes.extend_from_slice(b": ");
             let _ = bytes.extend_from_slice(header.value.as_bytes());
-            let _ = bytes.extend_from_slice(b"\r\n");
+            let _ = bytes.extend_from_slice(CRLF);
         }
 
         // Content-Length header if body is present
@@ -129,11 +132,11 @@ impl HttpResponse<'_> {
         if !body_bytes.is_empty() {
             let _ = bytes.extend_from_slice(b"Content-Length: ");
             write_decimal_to_buffer(&mut bytes, body_bytes.len());
-            let _ = bytes.extend_from_slice(b"\r\n");
+            let _ = bytes.extend_from_slice(CRLF);
         }
 
         // End of headers
-        let _ = bytes.extend_from_slice(b"\r\n");
+        let _ = bytes.extend_from_slice(CRLF);
 
         // Body
         let _ = bytes.extend_from_slice(body_bytes);
@@ -156,7 +159,7 @@ fn write_status_line<const MAX_RESPONSE_SIZE: usize>(
     // Write " <reason>\r\n"
     let _ = bytes.push(b' ');
     let _ = bytes.extend_from_slice(status_code.text().as_bytes());
-    let _ = bytes.extend_from_slice(b"\r\n");
+    let _ = bytes.extend_from_slice(CRLF);
 }
 
 /// Write a decimal number to the buffer


### PR DESCRIPTION

### Added

- Support for `Transfer-Encoding: chunked` responses. Chunked bodies are decoded in-place before parsing ([#29](https://github.com/rttfd/nanofish/issues/29)).

### Fixed

- Removed unsafe dangling pointer usage from README examples ([#28](https://github.com/rttfd/nanofish/issues/28)).

### Changed

- Bumped `defmt` from `1.0.1` to `1.1.0`.
- Bumped `heapless` from `0.9.2` to `0.9.3`.