### PR TITLE
v0.11.5: Bug fixes, protocol hardening, dual-stack DNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.5] - 2026-05-21
 
+### Added
+
+- `Error::BufferOverflow` variant for request/response buffer overflow errors.
+- Server read loop: accumulates data across multiple TCP segments until headers and `Content-Length` body are fully received.
+
+### Fixed
+
+- Client read loop now returns error on retry exhaustion instead of parsing partial/truncated data.
+- Empty URL path (e.g. `http://example.com`) now defaults to `"/"` instead of producing an invalid request line.
+- Handler timeout now returns `408 Request Timeout` instead of `400 Bad Request`.
+- Duplicate `Content-Length` header no longer emitted when caller already provides one in `build_bytes`.
+- `build_bytes` now returns `Result` and reports `BufferOverflow` instead of silently truncating.
+- `ResponseBody::Empty.as_str()` now returns `None` instead of `Some("")`.
+- Client handles missing or invalid `Content-Length` (e.g. Traefik stripping headers) by reading until connection close.
+
 ### Changed
 
 - Replaced unnecessary `proto-ipv6` with `proto-ipv4` in `embassy-net` features (the crate only uses IPv4 DNS queries).
 - Replaced all hardcoded HTTP strings in production code with constants from `protocol.rs` and `header.rs` (`CONTENT_TYPE`, `CONTENT_LENGTH`, `HEADER_SEPARATOR`, `HTTP_VERSION_PREFIX`, `mime_types::*`).
-- Server 500 error response now uses `HttpResponse::build_bytes` instead of a raw byte literal.
+- Server error responses extracted into `text_error_response` helper (DRY).
+- `handle_connection` changed from `&mut self` to `&self`.
+- `try_push!` macro now returns `Error::BufferOverflow` instead of `Error::InvalidResponse`.
+- Removed dead `url_parts` vec and `MAX_URL_PARTS` constant from URL parsing.
+- Socket timeout reset after accept to avoid racing with read timeout.
+- Removed blanket `#[allow(dead_code)]` on `StatusCode` impl.
 
 ## [0.11.4] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Error::BufferOverflow` variant for request/response buffer overflow errors.
 - Server read loop: accumulates data across multiple TCP segments until headers and `Content-Length` body are fully received.
+- IPv4/IPv6 dual-stack DNS resolution: tries A (IPv4) first, falls back to AAAA (IPv6).
 
 ### Fixed
 
@@ -26,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Replaced unnecessary `proto-ipv6` with `proto-ipv4` in `embassy-net` features (the crate only uses IPv4 DNS queries).
+- Enabled both `proto-ipv4` and `proto-ipv6` in `embassy-net` features for dual-stack support.
+- Extracted `resolve_host` helper to deduplicate DNS resolution between HTTP and HTTPS paths.
 - Replaced all hardcoded HTTP strings in production code with constants from `protocol.rs` and `header.rs` (`CONTENT_TYPE`, `CONTENT_LENGTH`, `HEADER_SEPARATOR`, `HTTP_VERSION_PREFIX`, `mime_types::*`).
 - Server error responses extracted into `text_error_response` helper (DRY).
 - `handle_connection` changed from `&mut self` to `&self`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.5] - 2026-05-21
+
+### Changed
+
+- Replaced unnecessary `proto-ipv6` with `proto-ipv4` in `embassy-net` features (the crate only uses IPv4 DNS queries).
+- Replaced all hardcoded HTTP strings in production code with constants from `protocol.rs` and `header.rs` (`CONTENT_TYPE`, `CONTENT_LENGTH`, `HEADER_SEPARATOR`, `HTTP_VERSION_PREFIX`, `mime_types::*`).
+- Server 500 error response now uses `HttpResponse::build_bytes` instead of a raw byte literal.
+
 ## [0.11.4] - 2026-05-18
 
 ### Added
@@ -179,10 +187,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, and CONNECT methods.
 - Configurable client options (retries, timeouts, delays).
 
-[Unreleased]: https://github.com/rttfd/nanofish/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/rttfd/nanofish/compare/v0.11.5...HEAD
+[0.11.5]: https://github.com/rttfd/nanofish/compare/v0.11.4...v0.11.5
+[0.11.4]: https://github.com/rttfd/nanofish/compare/v0.11.3...v0.11.4
+[0.11.3]: https://github.com/rttfd/nanofish/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/rttfd/nanofish/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/rttfd/nanofish/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/rttfd/nanofish/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/rttfd/nanofish/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/rttfd/nanofish/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/rttfd/nanofish/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/rttfd/nanofish/compare/v0.7.0...v0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ embassy-net = { version = "0.9.1", features = [
     "dns",
     "medium-ethernet",
     "proto-ipv4",
+    "proto-ipv6",
     "tcp",
 ] }
 embassy-time = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanofish"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 rust-version = "1.91"
 description = "🐟 A lightweight, `no_std` HTTP client and server for embedded systems built on top of Embassy networking."
@@ -21,7 +21,7 @@ defmt = { version = "1.1.0", optional = true }
 embassy-net = { version = "0.9.1", features = [
     "dns",
     "medium-ethernet",
-    "proto-ipv6",
+    "proto-ipv4",
     "tcp",
 ] }
 embassy-time = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Nanofish is designed for embedded systems with limited memory. It provides a sim
 - **Optional Logging** - Choose between `defmt` or `log` for diagnostics, or disable both for zero overhead
 - **Timeout & Retry Support** - Built-in handling for network issues
 - **Proxy Compatible** - Works behind reverse proxies (e.g. Traefik) that may strip or modify `Content-Length` headers
-- **DNS Resolution** - Automatic hostname resolution
+- **DNS Resolution** - Automatic hostname resolution with IPv4/IPv6 dual-stack support
 
 ## Installation & Feature Flags
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Nanofish is designed for embedded systems with limited memory. It provides a sim
 ### Basic HTTP Support (Default)
 ```toml
 [dependencies]
-nanofish = "0.11.4"
+nanofish = "0.11.5"
 ```
 
 ### With TLS/HTTPS Support

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Nanofish is designed for embedded systems with limited memory. It provides a sim
 - **Optional TLS Support** - HTTPS client support with embedded-tls when enabled (server is HTTP-only)
 - **Optional Logging** - Choose between `defmt` or `log` for diagnostics, or disable both for zero overhead
 - **Timeout & Retry Support** - Built-in handling for network issues
+- **Proxy Compatible** - Works behind reverse proxies (e.g. Traefik) that may strip or modify `Content-Length` headers
 - **DNS Resolution** - Automatic hostname resolution
 
 ## Installation & Feature Flags

--- a/src/client.rs
+++ b/src/client.rs
@@ -844,7 +844,8 @@ impl<
             return body_received >= content_length;
         }
 
-        true
+        // No Content-Length and not chunked: keep reading until connection closes (Ok(0))
+        false
     }
 
     /// Check if the response uses chunked transfer encoding
@@ -940,8 +941,17 @@ mod tests {
     use embassy_net::Stack;
 
     #[test]
-    fn test_is_response_complete_headers_only() {
+    fn test_is_response_complete_no_content_length() {
+        // Without Content-Length or chunked, response is never "complete" —
+        // the read loop must rely on connection close (Ok(0))
         let data = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n";
+        assert!(!DefaultHttpClient::is_response_complete(data));
+    }
+
+    #[test]
+    fn test_is_response_complete_content_length_zero() {
+        // Content-Length: 0 means empty body — complete once headers end
+        let data = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
         assert!(DefaultHttpClient::is_response_complete(data));
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use crate::{
     protocol::{
         self, CHUNKED, CHUNKED_END_MARKER, CONNECTION_CLOSE_END, CRLF_LEN, CRLF_STR,
         DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT, DOUBLE_CRLF_LEN, HEADER_SEPARATOR,
-        HTTP_VERSION_LINE_SUFFIX, MAX_HEADERS, MAX_URL_PARTS, TRANSFER_ENCODING,
+        HTTP_VERSION_LINE_SUFFIX, MAX_HEADERS, TRANSFER_ENCODING,
     },
     response::{HttpResponse, ResponseBody},
     status_code::StatusCode,
@@ -189,18 +189,9 @@ impl<
             return Err(Error::InvalidUrl);
         };
 
-        let mut url_parts = heapless::Vec::<&str, MAX_URL_PARTS>::new();
-        for part in host_port.splitn(MAX_URL_PARTS, '/') {
-            if url_parts.push(part).is_err() {
-                break;
-            }
-        }
-        if url_parts.is_empty() {
-            return Err(Error::InvalidUrl);
-        }
-
-        let host = url_parts[0];
+        let host = host_port.split('/').next().ok_or(Error::InvalidUrl)?;
         let path = &host_port[host.len()..];
+        let path = if path.is_empty() { "/" } else { path };
 
         let default_port = if scheme == "https" {
             DEFAULT_HTTPS_PORT

--- a/src/client.rs
+++ b/src/client.rs
@@ -230,6 +230,22 @@ impl<
         Ok((response, total_read))
     }
 
+    /// Resolve a hostname to an IP address, trying IPv4 (A) first then IPv6 (AAAA).
+    async fn resolve_host(stack: Stack<'_>, host: &str) -> Result<embassy_net::IpAddress, Error> {
+        let dns_socket = DnsSocket::new(stack);
+
+        // Try A (IPv4) first — most common on embedded networks
+        if let Ok(addrs) = dns_socket.query(host, dns::DnsQueryType::A).await
+            && let Some(&addr) = addrs.first()
+        {
+            return Ok(addr);
+        }
+
+        // Fall back to AAAA (IPv6)
+        let addrs = dns_socket.query(host, dns::DnsQueryType::Aaaa).await?;
+        addrs.first().copied().ok_or(Error::IpAddressEmpty)
+    }
+
     /// Make HTTPS request over TLS with zero-copy response handling
     #[cfg(feature = "tls")]
     async fn make_https_request(
@@ -247,14 +263,7 @@ impl<
         let mut socket = TcpSocket::new(*self.stack, &mut rx_buffer, &mut tx_buffer);
         socket.set_timeout(Some(self.options.socket_timeout));
 
-        let dns_socket = DnsSocket::new(*self.stack);
-        let ip_addresses = dns_socket.query(host, dns::DnsQueryType::A).await?;
-
-        if ip_addresses.is_empty() {
-            return Err(Error::IpAddressEmpty);
-        }
-
-        let ip_addr = ip_addresses[0];
+        let ip_addr = Self::resolve_host(*self.stack, host).await?;
         let remote_endpoint = (ip_addr, port);
 
         socket
@@ -342,14 +351,7 @@ impl<
         let mut socket = TcpSocket::new(*self.stack, &mut rx_buffer, &mut tx_buffer);
         socket.set_timeout(Some(self.options.socket_timeout));
 
-        let dns_socket = DnsSocket::new(*self.stack);
-        let ip_addresses = dns_socket.query(host, dns::DnsQueryType::A).await?;
-
-        if ip_addresses.is_empty() {
-            return Err(Error::IpAddressEmpty);
-        }
-
-        let ip_addr = ip_addresses[0];
+        let ip_addr = Self::resolve_host(*self.stack, host).await?;
         let remote_endpoint = (ip_addr, port);
 
         socket

--- a/src/client.rs
+++ b/src/client.rs
@@ -806,7 +806,7 @@ impl<
             )
             .is_err()
             {
-                return Err(Error::InvalidResponse("Failed to write content length"));
+                return Err(Error::BufferOverflow);
             }
             try_push!(http_request.push_str(&len_str));
             try_push!(http_request.push_str(CRLF_STR));

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,8 +7,9 @@ use crate::{
     method::HttpMethod,
     options::HttpClientOptions,
     protocol::{
-        self, CHUNKED, CHUNKED_END_MARKER, CRLF_LEN, DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT,
-        DOUBLE_CRLF_LEN, HTTP_VERSION_LINE_SUFFIX, MAX_HEADERS, MAX_URL_PARTS, TRANSFER_ENCODING,
+        self, CHUNKED, CHUNKED_END_MARKER, CONNECTION_CLOSE_END, CRLF_LEN, CRLF_STR,
+        DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT, DOUBLE_CRLF_LEN, HEADER_SEPARATOR,
+        HTTP_VERSION_LINE_SUFFIX, MAX_HEADERS, MAX_URL_PARTS, TRANSFER_ENCODING,
     },
     response::{HttpResponse, ResponseBody},
     status_code::StatusCode,
@@ -23,7 +24,7 @@ use embassy_time::Instant;
 use embassy_time::Timer;
 use embedded_io_async::Write as EmbeddedWrite;
 #[cfg(feature = "tls")]
-use embedded_tls::{Aes128GcmSha256, TlsConfig, TlsConnection, TlsContext};
+use embedded_tls::{Aes128GcmSha256, TlsConfig, TlsConnection, TlsContext, UnsecureProvider};
 use heapless::Vec;
 #[cfg(feature = "tls")]
 use rand_chacha::ChaCha8Rng;
@@ -249,8 +250,6 @@ impl<
         body: Option<&[u8]>,
         response_buffer: &mut [u8],
     ) -> Result<usize, Error> {
-        use embedded_tls::UnsecureProvider;
-
         let (host, port) = host_port;
         let mut rx_buffer = [0; TCP_RX];
         let mut tx_buffer = [0; TCP_TX];
@@ -691,7 +690,7 @@ impl<
             &response_str[status_line_end + CRLF_LEN..headers_end - DOUBLE_CRLF_LEN];
         let mut headers = Vec::<HttpHeader<'_>, MAX_HEADERS>::new();
 
-        for header_line in headers_section.split("\r\n") {
+        for header_line in headers_section.split(CRLF_STR) {
             if let Some(colon_pos) = header_line.find(':') {
                 let name = header_line[..colon_pos].trim();
                 let value = header_line[colon_pos + 1..].trim();
@@ -787,15 +786,15 @@ impl<
         try_push!(http_request.push_str(HTTP_VERSION_LINE_SUFFIX));
         try_push!(http_request.push_str("Host: "));
         try_push!(http_request.push_str(host));
-        try_push!(http_request.push_str("\r\n"));
+        try_push!(http_request.push_str(CRLF_STR));
 
         let mut content_length_present = false;
 
         for header in headers {
             try_push!(http_request.push_str(header.name));
-            try_push!(http_request.push_str(": "));
+            try_push!(http_request.push_str(HEADER_SEPARATOR));
             try_push!(http_request.push_str(header.value));
-            try_push!(http_request.push_str("\r\n"));
+            try_push!(http_request.push_str(CRLF_STR));
 
             if header.name.eq_ignore_ascii_case(CONTENT_LENGTH) {
                 content_length_present = true;
@@ -804,7 +803,8 @@ impl<
 
         // Add Content-Length header if body is present and not already specified
         if !content_length_present && body.is_some() {
-            try_push!(http_request.push_str("Content-Length: "));
+            try_push!(http_request.push_str(CONTENT_LENGTH));
+            try_push!(http_request.push_str(HEADER_SEPARATOR));
             let mut len_str = heapless::String::<8>::new();
             if core::fmt::write(
                 &mut len_str,
@@ -815,10 +815,10 @@ impl<
                 return Err(Error::InvalidResponse("Failed to write content length"));
             }
             try_push!(http_request.push_str(&len_str));
-            try_push!(http_request.push_str("\r\n"));
+            try_push!(http_request.push_str(CRLF_STR));
         }
 
-        try_push!(http_request.push_str("Connection: close\r\n\r\n"));
+        try_push!(http_request.push_str(CONNECTION_CLOSE_END));
 
         Ok(http_request)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -58,7 +58,7 @@ pub type SmallHttpClient<'a> = HttpClient<
 macro_rules! try_push {
     ($expr:expr) => {
         if $expr.is_err() {
-            return Err(Error::InvalidResponse("Request buffer overflow"));
+            return Err(Error::BufferOverflow);
         }
     };
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -396,6 +396,9 @@ impl<
                     retries -= 1;
                     if retries > 0 {
                         Timer::after(self.options.retry_delay).await;
+                    } else {
+                        socket.close();
+                        return Err(Error::from(e));
                     }
                 }
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
     HeaderError(&'static str),
     /// Invalid status code received from the server
     InvalidStatusCode,
+    /// Buffer overflow when building a request or response
+    BufferOverflow,
 }
 
 #[cfg(feature = "defmt")]
@@ -78,6 +80,7 @@ impl core::fmt::Display for Error {
             Error::UnsupportedScheme(scheme) => write!(f, "Unsupported scheme: {scheme}"),
             Error::HeaderError(msg) => write!(f, "Header error: {msg}"),
             Error::InvalidStatusCode => write!(f, "Invalid status code"),
+            Error::BufferOverflow => write!(f, "Buffer overflow"),
         }
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    header::HttpHeader,
+    header::{HttpHeader, mime_types},
     request::HttpRequest,
     response::{HttpResponse, ResponseBody},
     status_code::StatusCode,
@@ -23,7 +23,7 @@ impl HttpHandler for SimpleHandler {
         let mut headers = Vec::new();
         match request.path {
             "/" => {
-                let _ = headers.push(HttpHeader::new("Content-Type", "text/html"));
+                let _ = headers.push(HttpHeader::content_type(mime_types::HTML));
                 Ok(HttpResponse {
                     status_code: StatusCode::Ok,
                     headers,
@@ -31,7 +31,7 @@ impl HttpHandler for SimpleHandler {
                 })
             }
             "/health" => {
-                let _ = headers.push(HttpHeader::new("Content-Type", "application/json"));
+                let _ = headers.push(HttpHeader::content_type(mime_types::JSON));
                 Ok(HttpResponse {
                     status_code: StatusCode::Ok,
                     headers,
@@ -39,7 +39,7 @@ impl HttpHandler for SimpleHandler {
                 })
             }
             _ => {
-                let _ = headers.push(HttpHeader::new("Content-Type", "text/plain"));
+                let _ = headers.push(HttpHeader::content_type(mime_types::TEXT));
                 Ok(HttpResponse {
                     status_code: StatusCode::NotFound,
                     headers,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,13 +1,19 @@
 //! HTTP protocol constants and shared utilities.
 
-/// Carriage Return + Line Feed
+/// Carriage Return + Line Feed (bytes)
 pub const CRLF: &[u8] = b"\r\n";
+
+/// Carriage Return + Line Feed (string)
+pub const CRLF_STR: &str = "\r\n";
 
 /// Length of CRLF
 pub const CRLF_LEN: usize = CRLF.len();
 
-/// Double CRLF — separates HTTP headers from body
+/// Double CRLF — separates HTTP headers from body (bytes)
 pub const DOUBLE_CRLF: &[u8] = b"\r\n\r\n";
+
+/// Double CRLF (string)
+pub const DOUBLE_CRLF_STR: &str = "\r\n\r\n";
 
 /// Length of double CRLF
 pub const DOUBLE_CRLF_LEN: usize = DOUBLE_CRLF.len();
@@ -18,7 +24,10 @@ pub const CHUNKED_END_MARKER: &[u8] = b"0\r\n\r\n";
 /// HTTP/1.1 version string
 pub const HTTP_VERSION: &str = "HTTP/1.1";
 
-/// HTTP/1.1 version as bytes with leading space and trailing CRLF (for request line)
+/// HTTP/1.1 version bytes with leading space
+pub const HTTP_VERSION_PREFIX: &[u8] = b"HTTP/1.1 ";
+
+/// HTTP/1.1 version as string with leading space and trailing CRLF (for request line)
 pub const HTTP_VERSION_LINE_SUFFIX: &str = " HTTP/1.1\r\n";
 
 /// Default HTTP port
@@ -32,6 +41,12 @@ pub const TRANSFER_ENCODING: &str = "Transfer-Encoding";
 
 /// Chunked transfer encoding value
 pub const CHUNKED: &str = "chunked";
+
+/// Header-value separator
+pub const HEADER_SEPARATOR: &str = ": ";
+
+/// Connection close header line with trailing CRLF and end-of-headers CRLF
+pub const CONNECTION_CLOSE_END: &str = "Connection: close\r\n\r\n";
 
 /// Maximum number of headers allowed in requests and responses
 pub const MAX_HEADERS: usize = 16;
@@ -56,7 +71,7 @@ pub fn find_crlf(data: &[u8]) -> Option<usize> {
 /// Check if a header name matches (case-insensitive) and return its value.
 #[must_use]
 pub fn find_header_value<'a>(headers_str: &'a str, target_name: &str) -> Option<&'a str> {
-    for line in headers_str.split("\r\n") {
+    for line in headers_str.split(CRLF_STR) {
         if let Some(colon_pos) = line.find(':') {
             let name = line[..colon_pos].trim();
             let value = line[colon_pos + 1..].trim();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -51,9 +51,6 @@ pub const CONNECTION_CLOSE_END: &str = "Connection: close\r\n\r\n";
 /// Maximum number of headers allowed in requests and responses
 pub const MAX_HEADERS: usize = 16;
 
-/// Maximum URL path segments
-pub const MAX_URL_PARTS: usize = 8;
-
 /// Find the position of the double CRLF sequence in raw bytes.
 /// Returns the byte index of the start of `\r\n\r\n`.
 #[must_use]

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,6 @@
 use crate::{
     HttpHeader, StatusCode,
+    error::Error,
     header::headers::{CONTENT_LENGTH, CONTENT_TYPE},
     protocol::{CRLF, HEADER_SEPARATOR, HTTP_VERSION_PREFIX, MAX_HEADERS},
 };
@@ -113,20 +114,25 @@ impl HttpResponse<'_> {
     }
 
     /// Build HTTP response bytes from this `HttpResponse`
-    #[must_use]
-    pub fn build_bytes<const MAX_RESPONSE_SIZE: usize>(&self) -> Vec<u8, MAX_RESPONSE_SIZE> {
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if the response exceeds `MAX_RESPONSE_SIZE`.
+    pub fn build_bytes<const MAX_RESPONSE_SIZE: usize>(
+        &self,
+    ) -> Result<Vec<u8, MAX_RESPONSE_SIZE>, Error> {
         let mut bytes = Vec::new();
 
         // Status line: HTTP/1.1 <code> <reason>\r\n
-        write_status_line(&mut bytes, self.status_code);
+        write_status_line(&mut bytes, self.status_code)?;
 
         // Headers
         let mut has_content_length = false;
         for header in &self.headers {
-            let _ = bytes.extend_from_slice(header.name.as_bytes());
-            let _ = bytes.extend_from_slice(HEADER_SEPARATOR.as_bytes());
-            let _ = bytes.extend_from_slice(header.value.as_bytes());
-            let _ = bytes.extend_from_slice(CRLF);
+            push_slice(&mut bytes, header.name.as_bytes())?;
+            push_slice(&mut bytes, HEADER_SEPARATOR.as_bytes())?;
+            push_slice(&mut bytes, header.value.as_bytes())?;
+            push_slice(&mut bytes, CRLF)?;
             if header.name.eq_ignore_ascii_case(CONTENT_LENGTH) {
                 has_content_length = true;
             }
@@ -135,47 +141,48 @@ impl HttpResponse<'_> {
         // Content-Length header if body is present and not already specified
         let body_bytes = self.body.as_bytes();
         if !has_content_length && !body_bytes.is_empty() {
-            let _ = bytes.extend_from_slice(CONTENT_LENGTH.as_bytes());
-            let _ = bytes.extend_from_slice(HEADER_SEPARATOR.as_bytes());
-            write_decimal_to_buffer(&mut bytes, body_bytes.len());
-            let _ = bytes.extend_from_slice(CRLF);
+            push_slice(&mut bytes, CONTENT_LENGTH.as_bytes())?;
+            push_slice(&mut bytes, HEADER_SEPARATOR.as_bytes())?;
+            write_decimal_to_buffer(&mut bytes, body_bytes.len())?;
+            push_slice(&mut bytes, CRLF)?;
         }
 
         // End of headers
-        let _ = bytes.extend_from_slice(CRLF);
+        push_slice(&mut bytes, CRLF)?;
 
         // Body
-        let _ = bytes.extend_from_slice(body_bytes);
+        push_slice(&mut bytes, body_bytes)?;
 
-        bytes
+        Ok(bytes)
     }
 }
 
+/// Push a byte slice into the buffer, returning `BufferOverflow` on failure.
+fn push_slice<const N: usize>(bytes: &mut Vec<u8, N>, data: &[u8]) -> Result<(), Error> {
+    bytes
+        .extend_from_slice(data)
+        .map_err(|_| Error::BufferOverflow)
+}
+
 /// Write HTTP status line to the given buffer
-fn write_status_line<const MAX_RESPONSE_SIZE: usize>(
-    bytes: &mut Vec<u8, MAX_RESPONSE_SIZE>,
+fn write_status_line<const N: usize>(
+    bytes: &mut Vec<u8, N>,
     status_code: StatusCode,
-) {
-    // Write "HTTP/1.1 "
-    let _ = bytes.extend_from_slice(HTTP_VERSION_PREFIX);
-
-    // Write status code as decimal
-    write_decimal_to_buffer(bytes, status_code.as_u16() as usize);
-
-    // Write " <reason>\r\n"
-    let _ = bytes.push(b' ');
-    let _ = bytes.extend_from_slice(status_code.text().as_bytes());
-    let _ = bytes.extend_from_slice(CRLF);
+) -> Result<(), Error> {
+    push_slice(bytes, HTTP_VERSION_PREFIX)?;
+    write_decimal_to_buffer(bytes, status_code.as_u16() as usize)?;
+    bytes.push(b' ').map_err(|_| Error::BufferOverflow)?;
+    push_slice(bytes, status_code.text().as_bytes())?;
+    push_slice(bytes, CRLF)
 }
 
 /// Write a decimal number to the buffer
-fn write_decimal_to_buffer<const MAX_RESPONSE_SIZE: usize>(
-    bytes: &mut Vec<u8, MAX_RESPONSE_SIZE>,
+fn write_decimal_to_buffer<const N: usize>(
+    bytes: &mut Vec<u8, N>,
     mut num: usize,
-) {
+) -> Result<(), Error> {
     if num == 0 {
-        let _ = bytes.push(b'0');
-        return;
+        return bytes.push(b'0').map_err(|_| Error::BufferOverflow);
     }
 
     let mut digits = [0u8; 10];
@@ -190,10 +197,10 @@ fn write_decimal_to_buffer<const MAX_RESPONSE_SIZE: usize>(
         i += 1;
     }
 
-    // Write digits in reverse order
     for j in (0..i).rev() {
-        let _ = bytes.push(digits[j]);
+        bytes.push(digits[j]).map_err(|_| Error::BufferOverflow)?;
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -258,7 +265,7 @@ mod tests {
             body: ResponseBody::Text("Hello World!"),
         };
 
-        let bytes = response.build_bytes::<4096>();
+        let bytes = response.build_bytes::<4096>().unwrap();
         let response_str = core::str::from_utf8(&bytes).unwrap();
 
         assert!(response_str.starts_with("HTTP/1.1 200 OK\r\n"));
@@ -275,7 +282,7 @@ mod tests {
             body: ResponseBody::Text("Not Found"),
         };
 
-        let bytes = response.build_bytes::<4096>();
+        let bytes = response.build_bytes::<4096>().unwrap();
         let response_str = core::str::from_utf8(&bytes).unwrap();
 
         assert!(response_str.starts_with("HTTP/1.1 404 Not Found\r\n"));
@@ -291,7 +298,7 @@ mod tests {
             body: ResponseBody::Empty,
         };
 
-        let bytes = response.build_bytes::<4096>();
+        let bytes = response.build_bytes::<4096>().unwrap();
         let response_str = core::str::from_utf8(&bytes).unwrap();
 
         assert!(response_str.starts_with("HTTP/1.1 204 No Content\r\n"));
@@ -308,7 +315,7 @@ mod tests {
             body: ResponseBody::Binary(binary_data),
         };
 
-        let bytes = response.build_bytes::<4096>();
+        let bytes = response.build_bytes::<4096>().unwrap();
 
         // Check that the response contains the binary data at the end
         assert!(bytes.ends_with(binary_data));
@@ -323,25 +330,25 @@ mod tests {
         let mut bytes: Vec<u8, 64> = Vec::new();
 
         // Test zero
-        write_decimal_to_buffer(&mut bytes, 0);
+        write_decimal_to_buffer(&mut bytes, 0).unwrap();
         assert_eq!(bytes, b"0");
 
         // Test single digit
         bytes.clear();
-        write_decimal_to_buffer(&mut bytes, 5);
+        write_decimal_to_buffer(&mut bytes, 5).unwrap();
         assert_eq!(bytes, b"5");
 
         // Test multi-digit numbers
         bytes.clear();
-        write_decimal_to_buffer(&mut bytes, 42);
+        write_decimal_to_buffer(&mut bytes, 42).unwrap();
         assert_eq!(bytes, b"42");
 
         bytes.clear();
-        write_decimal_to_buffer(&mut bytes, 123);
+        write_decimal_to_buffer(&mut bytes, 123).unwrap();
         assert_eq!(bytes, b"123");
 
         bytes.clear();
-        write_decimal_to_buffer(&mut bytes, 9999);
+        write_decimal_to_buffer(&mut bytes, 9999).unwrap();
         assert_eq!(bytes, b"9999");
     }
 
@@ -350,19 +357,19 @@ mod tests {
         let mut bytes: Vec<u8, 64> = Vec::new();
 
         // Test common status codes
-        write_status_line(&mut bytes, StatusCode::Ok);
+        write_status_line(&mut bytes, StatusCode::Ok).unwrap();
         assert_eq!(bytes, b"HTTP/1.1 200 OK\r\n");
 
         bytes.clear();
-        write_status_line(&mut bytes, StatusCode::NotFound);
+        write_status_line(&mut bytes, StatusCode::NotFound).unwrap();
         assert_eq!(bytes, b"HTTP/1.1 404 Not Found\r\n");
 
         bytes.clear();
-        write_status_line(&mut bytes, StatusCode::InternalServerError);
+        write_status_line(&mut bytes, StatusCode::InternalServerError).unwrap();
         assert_eq!(bytes, b"HTTP/1.1 500 Internal Server Error\r\n");
 
         bytes.clear();
-        write_status_line(&mut bytes, StatusCode::Created);
+        write_status_line(&mut bytes, StatusCode::Created).unwrap();
         assert_eq!(bytes, b"HTTP/1.1 201 Created\r\n");
     }
 
@@ -388,7 +395,7 @@ mod tests {
                 body: ResponseBody::Text(body_text),
             };
 
-            let bytes = response.build_bytes::<4096>();
+            let bytes = response.build_bytes::<4096>().unwrap();
             let response_str = core::str::from_utf8(&bytes).unwrap();
 
             if *expected_len > 0 {

--- a/src/response.rs
+++ b/src/response.rs
@@ -24,7 +24,7 @@ impl ResponseBody<'_> {
         match self {
             ResponseBody::Text(s) => Some(s),
             ResponseBody::Binary(bytes) => core::str::from_utf8(bytes).ok(),
-            ResponseBody::Empty => Some(""),
+            ResponseBody::Empty => None,
         }
     }
 
@@ -218,7 +218,7 @@ mod tests {
         assert_eq!(bin.as_str(), Some("bin"));
         assert_eq!(bin.as_bytes(), b"bin");
         let empty = ResponseBody::Empty;
-        assert_eq!(empty.as_str(), Some(""));
+        assert_eq!(empty.as_str(), None);
         assert_eq!(empty.as_bytes(), b"");
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -121,16 +121,20 @@ impl HttpResponse<'_> {
         write_status_line(&mut bytes, self.status_code);
 
         // Headers
+        let mut has_content_length = false;
         for header in &self.headers {
             let _ = bytes.extend_from_slice(header.name.as_bytes());
             let _ = bytes.extend_from_slice(HEADER_SEPARATOR.as_bytes());
             let _ = bytes.extend_from_slice(header.value.as_bytes());
             let _ = bytes.extend_from_slice(CRLF);
+            if header.name.eq_ignore_ascii_case(CONTENT_LENGTH) {
+                has_content_length = true;
+            }
         }
 
-        // Content-Length header if body is present
+        // Content-Length header if body is present and not already specified
         let body_bytes = self.body.as_bytes();
-        if !body_bytes.is_empty() {
+        if !has_content_length && !body_bytes.is_empty() {
             let _ = bytes.extend_from_slice(CONTENT_LENGTH.as_bytes());
             let _ = bytes.extend_from_slice(HEADER_SEPARATOR.as_bytes());
             write_decimal_to_buffer(&mut bytes, body_bytes.len());

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,7 @@
 use crate::{
     HttpHeader, StatusCode,
-    protocol::{CRLF, MAX_HEADERS},
+    header::headers::{CONTENT_LENGTH, CONTENT_TYPE},
+    protocol::{CRLF, HEADER_SEPARATOR, HTTP_VERSION_PREFIX, MAX_HEADERS},
 };
 use heapless::Vec;
 
@@ -84,13 +85,13 @@ impl HttpResponse<'_> {
     /// Get the Content-Type header value
     #[must_use]
     pub fn content_type(&self) -> Option<&str> {
-        self.get_header("Content-Type")
+        self.get_header(CONTENT_TYPE)
     }
 
     /// Get the Content-Length header value as a number
     #[must_use]
     pub fn content_length(&self) -> Option<usize> {
-        self.get_header("Content-Length")?.parse().ok()
+        self.get_header(CONTENT_LENGTH)?.parse().ok()
     }
 
     /// Check if the response indicates success (2xx status codes)
@@ -122,7 +123,7 @@ impl HttpResponse<'_> {
         // Headers
         for header in &self.headers {
             let _ = bytes.extend_from_slice(header.name.as_bytes());
-            let _ = bytes.extend_from_slice(b": ");
+            let _ = bytes.extend_from_slice(HEADER_SEPARATOR.as_bytes());
             let _ = bytes.extend_from_slice(header.value.as_bytes());
             let _ = bytes.extend_from_slice(CRLF);
         }
@@ -130,7 +131,8 @@ impl HttpResponse<'_> {
         // Content-Length header if body is present
         let body_bytes = self.body.as_bytes();
         if !body_bytes.is_empty() {
-            let _ = bytes.extend_from_slice(b"Content-Length: ");
+            let _ = bytes.extend_from_slice(CONTENT_LENGTH.as_bytes());
+            let _ = bytes.extend_from_slice(HEADER_SEPARATOR.as_bytes());
             write_decimal_to_buffer(&mut bytes, body_bytes.len());
             let _ = bytes.extend_from_slice(CRLF);
         }
@@ -151,7 +153,7 @@ fn write_status_line<const MAX_RESPONSE_SIZE: usize>(
     status_code: StatusCode,
 ) {
     // Write "HTTP/1.1 "
-    let _ = bytes.extend_from_slice(b"HTTP/1.1 ");
+    let _ = bytes.extend_from_slice(HTTP_VERSION_PREFIX);
 
     // Write status code as decimal
     write_decimal_to_buffer(bytes, status_code.as_u16() as usize);

--- a/src/server.rs
+++ b/src/server.rs
@@ -149,12 +149,13 @@ impl<
                 }
                 Err(e) => {
                     error!("Error handling request: {:?}", e);
-                    let error_bytes = Self::text_error_response(
+                    if let Ok(error_bytes) = Self::text_error_response(
                         StatusCode::InternalServerError,
                         "Internal Server Error",
-                    );
-                    let _ = socket.write_all(&error_bytes).await;
-                    let _ = socket.flush().await;
+                    ) {
+                        let _ = socket.write_all(&error_bytes).await;
+                        let _ = socket.flush().await;
+                    }
                 }
             }
 
@@ -210,7 +211,10 @@ impl<
     }
 
     /// Build a plain-text error response.
-    fn text_error_response(status: StatusCode, body: &str) -> Vec<u8, MAX_RESPONSE_SIZE> {
+    fn text_error_response(
+        status: StatusCode,
+        body: &str,
+    ) -> Result<Vec<u8, MAX_RESPONSE_SIZE>, Error> {
         let mut headers = Vec::new();
         let _ = headers.push(HttpHeader::content_type(mime_types::TEXT));
         let resp = HttpResponse {
@@ -242,21 +246,21 @@ impl<
             Ok(Ok(response)) => response,
             Ok(Err(e)) => {
                 warn!("Handler error: {:?}", e);
-                return Ok(Self::text_error_response(
+                return Self::text_error_response(
                     StatusCode::InternalServerError,
                     "Internal Server Error",
-                ));
+                );
             }
             Err(_) => {
                 warn!("Request handling timed out");
-                return Ok(Self::text_error_response(
+                return Self::text_error_response(
                     StatusCode::RequestTimeout,
                     "Request Timeout",
-                ));
+                );
             }
         };
 
-        Ok(response.build_bytes::<MAX_RESPONSE_SIZE>())
+        response.build_bytes::<MAX_RESPONSE_SIZE>()
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::Error,
     handler::HttpHandler,
-    header::HttpHeader,
+    header::{HttpHeader, mime_types},
     request::HttpRequest,
     response::{HttpResponse, ResponseBody},
     status_code::StatusCode,
@@ -143,8 +143,15 @@ impl<
                 Err(e) => {
                     error!("Error handling request: {:?}", e);
                     // Send a 500 error response
-                    let error_response = b"HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: 21\r\n\r\nInternal Server Error";
-                    let _ = socket.write_all(error_response).await;
+                    let mut headers = Vec::new();
+                    let _ = headers.push(HttpHeader::content_type(mime_types::TEXT));
+                    let fallback = HttpResponse {
+                        status_code: StatusCode::InternalServerError,
+                        headers,
+                        body: ResponseBody::Text("Internal Server Error"),
+                    };
+                    let error_bytes = fallback.build_bytes::<MAX_RESPONSE_SIZE>();
+                    let _ = socket.write_all(&error_bytes).await;
                     let _ = socket.flush().await;
                 }
             }
@@ -175,7 +182,7 @@ impl<
             Ok(Err(e)) => {
                 warn!("Handler error: {:?}", e);
                 let mut headers = Vec::new();
-                let _ = headers.push(HttpHeader::new("Content-Type", "text/plain"));
+                let _ = headers.push(HttpHeader::content_type(mime_types::TEXT));
                 let error_response = HttpResponse {
                     status_code: StatusCode::InternalServerError,
                     headers,
@@ -186,7 +193,7 @@ impl<
             Err(_) => {
                 warn!("Request handling timed out");
                 let mut headers = Vec::new();
-                let _ = headers.push(HttpHeader::new("Content-Type", "text/plain"));
+                let _ = headers.push(HttpHeader::content_type(mime_types::TEXT));
                 let timeout_response = HttpResponse {
                     status_code: StatusCode::BadRequest,
                     headers,

--- a/src/server.rs
+++ b/src/server.rs
@@ -149,15 +149,10 @@ impl<
                 }
                 Err(e) => {
                     error!("Error handling request: {:?}", e);
-                    // Send a 500 error response
-                    let mut headers = Vec::new();
-                    let _ = headers.push(HttpHeader::content_type(mime_types::TEXT));
-                    let fallback = HttpResponse {
-                        status_code: StatusCode::InternalServerError,
-                        headers,
-                        body: ResponseBody::Text("Internal Server Error"),
-                    };
-                    let error_bytes = fallback.build_bytes::<MAX_RESPONSE_SIZE>();
+                    let error_bytes = Self::text_error_response(
+                        StatusCode::InternalServerError,
+                        "Internal Server Error",
+                    );
                     let _ = socket.write_all(&error_bytes).await;
                     let _ = socket.flush().await;
                 }
@@ -214,8 +209,20 @@ impl<
             .ok()
     }
 
+    /// Build a plain-text error response.
+    fn text_error_response(status: StatusCode, body: &str) -> Vec<u8, MAX_RESPONSE_SIZE> {
+        let mut headers = Vec::new();
+        let _ = headers.push(HttpHeader::content_type(mime_types::TEXT));
+        let resp = HttpResponse {
+            status_code: status,
+            headers,
+            body: ResponseBody::Text(body),
+        };
+        resp.build_bytes::<MAX_RESPONSE_SIZE>()
+    }
+
     async fn handle_connection<H>(
-        &mut self,
+        &self,
         buffer: &[u8],
         handler: &H,
     ) -> Result<Vec<u8, MAX_RESPONSE_SIZE>, Error>
@@ -235,25 +242,17 @@ impl<
             Ok(Ok(response)) => response,
             Ok(Err(e)) => {
                 warn!("Handler error: {:?}", e);
-                let mut headers = Vec::new();
-                let _ = headers.push(HttpHeader::content_type(mime_types::TEXT));
-                let error_response = HttpResponse {
-                    status_code: StatusCode::InternalServerError,
-                    headers,
-                    body: ResponseBody::Text("Internal Server Error"),
-                };
-                return Ok(error_response.build_bytes::<MAX_RESPONSE_SIZE>());
+                return Ok(Self::text_error_response(
+                    StatusCode::InternalServerError,
+                    "Internal Server Error",
+                ));
             }
             Err(_) => {
                 warn!("Request handling timed out");
-                let mut headers = Vec::new();
-                let _ = headers.push(HttpHeader::content_type(mime_types::TEXT));
-                let timeout_response = HttpResponse {
-                    status_code: StatusCode::BadRequest,
-                    headers,
-                    body: ResponseBody::Text("Request Timeout"),
-                };
-                return Ok(timeout_response.build_bytes::<MAX_RESPONSE_SIZE>());
+                return Ok(Self::text_error_response(
+                    StatusCode::RequestTimeout,
+                    "Request Timeout",
+                ));
             }
         };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -253,10 +253,7 @@ impl<
             }
             Err(_) => {
                 warn!("Request handling timed out");
-                return Self::text_error_response(
-                    StatusCode::RequestTimeout,
-                    "Request Timeout",
-                );
+                return Self::text_error_response(StatusCode::RequestTimeout, "Request Timeout");
             }
         };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,8 @@
 use crate::{
     error::Error,
     handler::HttpHandler,
-    header::{HttpHeader, mime_types},
+    header::{HttpHeader, headers::CONTENT_LENGTH, mime_types},
+    protocol::{self, DOUBLE_CRLF_LEN},
     request::HttpRequest,
     response::{HttpResponse, ResponseBody},
     status_code::StatusCode,
@@ -109,29 +110,35 @@ impl<
                 continue;
             }
 
-            let n = match with_timeout(
+            // Reset socket timeout after accept so it doesn't race with read timeout
+            socket.set_timeout(None);
+
+            // Read loop: accumulate data until headers + body are complete
+            let mut total_read = 0;
+            let read_ok = match with_timeout(
                 Duration::from_secs(self.timeouts.read_timeout),
-                socket.read(&mut buf),
+                Self::read_request(&mut socket, &mut buf, &mut total_read),
             )
             .await
             {
-                Ok(Ok(0)) => {
-                    // Connection closed
-                    continue;
-                }
-                Ok(Ok(n)) => n,
+                Ok(Ok(())) => true,
                 Ok(Err(e)) => {
                     warn!("Read error: {:?}", e);
-                    continue;
+                    false
                 }
                 Err(_) => {
                     warn!("Socket read timeout");
-                    continue;
+                    false
                 }
             };
 
+            if !read_ok || total_read == 0 {
+                socket.close();
+                continue;
+            }
+
             // Parse the request
-            match self.handle_connection(&buf[..n], &handler).await {
+            match self.handle_connection(&buf[..total_read], &handler).await {
                 Ok(response_bytes) => {
                     if let Err(e) = socket.write_all(&response_bytes).await {
                         warn!("Failed to write response: {:?}", e);
@@ -158,6 +165,53 @@ impl<
 
             socket.close();
         }
+    }
+
+    /// Read a complete HTTP request from the socket.
+    ///
+    /// Accumulates data until headers are found (`\r\n\r\n`), then reads
+    /// any remaining body bytes indicated by `Content-Length`.
+    async fn read_request(
+        socket: &mut TcpSocket<'_>,
+        buf: &mut [u8],
+        total_read: &mut usize,
+    ) -> Result<(), embassy_net::tcp::Error> {
+        let mut header_end = None;
+
+        while *total_read < buf.len() {
+            let n = socket.read(&mut buf[*total_read..]).await?;
+            if n == 0 {
+                break;
+            }
+            *total_read += n;
+
+            // Look for end of headers if not yet found
+            if header_end.is_none() {
+                header_end = protocol::find_double_crlf(&buf[..*total_read]);
+            }
+
+            if let Some(hdr_end) = header_end {
+                let body_start = hdr_end + DOUBLE_CRLF_LEN;
+                // Try to determine Content-Length from the headers
+                if let Some(cl) = Self::parse_content_length(&buf[..hdr_end]) {
+                    if *total_read >= body_start + cl {
+                        break;
+                    }
+                } else {
+                    // No Content-Length — headers are complete, no body expected
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Extract `Content-Length` value from raw header bytes.
+    fn parse_content_length(header_bytes: &[u8]) -> Option<usize> {
+        let headers_str = core::str::from_utf8(header_bytes).ok()?;
+        protocol::find_header_value(headers_str, CONTENT_LENGTH)?
+            .parse()
+            .ok()
     }
 
     async fn handle_connection<H>(

--- a/src/status_code.rs
+++ b/src/status_code.rs
@@ -96,7 +96,6 @@ pub enum StatusCode {
     Other(u16),
 }
 
-#[allow(dead_code)]
 impl StatusCode {
     /// Returns the numeric status code as u16.
     #[must_use]


### PR DESCRIPTION
Fixes correctness bugs in client/server read loops, hardens HTTP protocol handling, and adds IPv4/IPv6 dual-stack DNS resolution.

- **Client**: fix partial response on retry exhaustion, handle missing `Content-Length` (proxy compat), default empty path to `/`
- **Server**: multi-segment read loop, `408` on handler timeout, shared error response helper
- **Response**: `build_bytes` returns `Result` on overflow, skip duplicate `Content-Length`
- **DNS**: A then AAAA fallback, extracted `resolve_host` helper
- Replace hardcoded strings with protocol constants, add `Error::BufferOverflow`