### PR TITLE
docs: update README and CHANGELOG for v0.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.6] - TBD
+## [0.11.6] - 2026-05-27
 
 ### Added
 
@@ -229,7 +229,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, and CONNECT methods.
 - Configurable client options (retries, timeouts, delays).
 
-[Unreleased]: https://github.com/rttfd/nanofish/compare/v0.11.5...HEAD
+[Unreleased]: https://github.com/rttfd/nanofish/compare/v0.11.6...HEAD
+[0.11.6]: https://github.com/rttfd/nanofish/compare/v0.11.5...v0.11.6
 [0.11.5]: https://github.com/rttfd/nanofish/compare/v0.11.4...v0.11.5
 [0.11.4]: https://github.com/rttfd/nanofish/compare/v0.11.3...v0.11.4
 [0.11.3]: https://github.com/rttfd/nanofish/compare/v0.11.2...v0.11.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.6] - TBD
+
+### Added
+
+- Strict clippy configuration following nulid pattern: forbids `unwrap`/`expect`/`panic`/`todo`/`unimplemented` in production code (tests allow these via `.clippy.toml`), enables pedantic and nursery lints at warn level.
+
+### Changed
+
+- Replaced `rand_chacha` dependency with tiny XORShift32 PRNG for TLS seeding (keeps `rand_core 0.6` required by embedded-tls, removes rand 0.10.x conflict).
+- Added `const` to all functions that can be made `const` (`ResponseBody::as_bytes`, `ResponseBody::is_empty`, `ResponseBody::len`, `StatusCode::as_u16`, `StatusCode::text`, `ServerTimeouts::new`, `HttpServer::with_timeouts`, `XorShift32Rng::new`).
+- Use `Self` instead of type names within impls (`StatusCode`, `Error`, `HttpMethod`, `ResponseBody`).
+- Simplified `if let/else` patterns to `map_or`/`map_or_else` for better code clarity.
+- Added `Eq` derives to enums with `PartialEq` (`HttpMethod`, `InvalidHttpMethod`).
+- Replace `unwrap()` with safe array indexing for `timeseed()` in TLS seeding.
+- Used `#[expect(clippy::future_not_send)]` instead of `#[allow(...)]` for embedded async functions (documents intent and alerts if futures become `Send`).
+
+### Fixed
+
+- All 197 clippy warnings (pedantic/nursery lints) fixed without `#[allow(...)]` directives (except expected `future_not_send` for embedded no_std).
+
 ## [0.11.5] - 2026-05-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,24 +32,24 @@ Nanofish is designed for embedded systems with limited memory. It provides a sim
 ### Basic HTTP Support (Default)
 ```toml
 [dependencies]
-nanofish = "0.11.5"
+nanofish = "0.11.6"
 ```
 
 ### With TLS/HTTPS Support
 ```toml
 [dependencies]
-nanofish = { version = "0.11.5", features = ["tls"] }
+nanofish = { version = "0.11.6", features = ["tls"] }
 ```
 
 ### With Logging
 ```toml
 # Using defmt (common in embedded/probe-based workflows)
 [dependencies]
-nanofish = { version = "0.11.5", features = ["defmt"] }
+nanofish = { version = "0.11.6", features = ["defmt"] }
 
 # Using the log crate (common in std or defmt-incompatible environments)
 [dependencies]
-nanofish = { version = "0.11.5", features = ["log"] }
+nanofish = { version = "0.11.6", features = ["log"] }
 ```
 
 > **Note:** The `defmt` and `log` features are **mutually exclusive**. Enabling both will produce a compile-time error. If neither is enabled, all logging calls are compiled away to no-ops.
@@ -99,7 +99,7 @@ async fn example(stack: &Stack<'_>) -> Result<(), nanofish::Error> {
     let client = DefaultHttpClient::new(stack);
     let mut response_buffer = [0u8; 8192];
     let headers = [
-        HttpHeader::user_agent("Nanofish/0.11.5"),
+        HttpHeader::user_agent("Nanofish/0.11.6"),
         HttpHeader::content_type(mime_types::JSON),
         HttpHeader::authorization("Bearer token123"),
     ];


### PR DESCRIPTION
Updates version numbers and documentation for v0.11.6 release:

- Update version from 0.11.5 to 0.11.6 in README
- Add v0.11.6 changelog entry with all changes
- Add tag comparison link for v0.11.6