### PR TITLE
0.11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.7] - 2026-06-01
+
+### Added
+
+- SSE-friendly header helpers for `text/event-stream`, `Cache-Control`, and `Connection`.
+- `HttpResponse::build_head_bytes` for header-only responses, which makes streaming endpoints easier to wire up in embedded handlers.
+
+### Changed
+
+- Updated the README to call out the HTTP server path for embedded APIs such as Puck.
+
+
 ## [0.11.6] - 2026-05-27
 
 ### Added
@@ -229,7 +241,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, and CONNECT methods.
 - Configurable client options (retries, timeouts, delays).
 
-[Unreleased]: https://github.com/rttfd/nanofish/compare/v0.11.6...HEAD
+[Unreleased]: https://github.com/rttfd/nanofish/compare/v0.11.7...HEAD
+[0.11.7]: https://github.com/rttfd/nanofish/compare/v0.11.6...v0.11.7
 [0.11.6]: https://github.com/rttfd/nanofish/compare/v0.11.5...v0.11.6
 [0.11.5]: https://github.com/rttfd/nanofish/compare/v0.11.4...v0.11.5
 [0.11.4]: https://github.com/rttfd/nanofish/compare/v0.11.3...v0.11.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanofish"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 rust-version = "1.91"
 description = "🐟 A lightweight, `no_std` HTTP client and server for embedded systems built on top of Embassy networking."

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Nanofish is designed for embedded systems with limited memory. It provides a sim
 - **HTTP Server** - Built-in async server with customizable timeouts and request handling
 - **Smart Response Parsing** - Automatic text/binary detection based on Content-Type headers
 - **Easy Header Management** - Pre-defined constants and helper methods for common headers
+- **SSE-Friendly Headers** - `text/event-stream`, `Cache-Control`, and `Connection` helpers for streaming endpoints
 - **Optional TLS Support** - HTTPS client support with embedded-tls when enabled (server is HTTP-only)
 - **Optional Logging** - Choose between `defmt` or `log` for diagnostics, or disable both for zero overhead
 - **Timeout & Retry Support** - Built-in handling for network issues
@@ -32,24 +33,24 @@ Nanofish is designed for embedded systems with limited memory. It provides a sim
 ### Basic HTTP Support (Default)
 ```toml
 [dependencies]
-nanofish = "0.11.6"
+nanofish = "0.11.7"
 ```
 
 ### With TLS/HTTPS Support
 ```toml
 [dependencies]
-nanofish = { version = "0.11.6", features = ["tls"] }
+nanofish = { version = "0.11.7", features = ["tls"] }
 ```
 
 ### With Logging
 ```toml
 # Using defmt (common in embedded/probe-based workflows)
 [dependencies]
-nanofish = { version = "0.11.6", features = ["defmt"] }
+nanofish = { version = "0.11.7", features = ["defmt"] }
 
 # Using the log crate (common in std or defmt-incompatible environments)
 [dependencies]
-nanofish = { version = "0.11.6", features = ["log"] }
+nanofish = { version = "0.11.7", features = ["log"] }
 ```
 
 > **Note:** The `defmt` and `log` features are **mutually exclusive**. Enabling both will produce a compile-time error. If neither is enabled, all logging calls are compiled away to no-ops.
@@ -99,7 +100,7 @@ async fn example(stack: &Stack<'_>) -> Result<(), nanofish::Error> {
     let client = DefaultHttpClient::new(stack);
     let mut response_buffer = [0u8; 8192];
     let headers = [
-        HttpHeader::user_agent("Nanofish/0.11.6"),
+        HttpHeader::user_agent("Nanofish/0.11.7"),
         HttpHeader::content_type(mime_types::JSON),
         HttpHeader::authorization("Bearer token123"),
     ];
@@ -332,6 +333,8 @@ for url in urls {
 
 Nanofish includes a built-in HTTP server perfect for embedded systems and `IoT` devices. The server is async, lightweight, and has customizable timeouts.
 
+For streaming endpoints such as server-sent events, use the `Content-Type: text/event-stream`, `Cache-Control: no-cache`, and `Connection: keep-alive` helpers, plus the response head builder when you need to send headers before the body stream starts.
+
 > **Important Note**: The server only supports plain HTTP connections, not HTTPS/TLS. While the Nanofish client supports both HTTP and HTTPS, the server implementation is HTTP-only. For secure connections in production, use a reverse proxy (like nginx) or load balancer that handles TLS termination.
 
 ### Basic Server Usage
@@ -344,7 +347,7 @@ use embassy_net::Stack;
 struct MyHandler;
 
 impl HttpHandler for MyHandler {
-    async fn handle_request(&mut self, request: &HttpRequest<'_>) -> Result<HttpResponse<'_>, nanofish::Error> {
+    async fn handle_request(&self, request: &HttpRequest<'_>) -> Result<HttpResponse<'_>, nanofish::Error> {
         match request.path {
             "/" => Ok(HttpResponse {
                 status_code: StatusCode::Ok,

--- a/src/header.rs
+++ b/src/header.rs
@@ -36,6 +36,8 @@ pub mod mime_types {
     pub const FORM: &str = "application/x-www-form-urlencoded";
     /// application/octet-stream
     pub const BINARY: &str = "application/octet-stream";
+    /// text/event-stream
+    pub const EVENT_STREAM: &str = "text/event-stream";
 }
 
 /// HTTP Header struct for representing a single header with owned strings
@@ -76,6 +78,18 @@ impl<'a> HttpHeader<'a> {
         Self::new(headers::USER_AGENT, value)
     }
 
+    /// Create a Cache-Control header
+    #[must_use]
+    pub const fn cache_control(value: &'a str) -> Self {
+        Self::new(headers::CACHE_CONTROL, value)
+    }
+
+    /// Create a Connection header
+    #[must_use]
+    pub const fn connection(value: &'a str) -> Self {
+        Self::new(headers::CONNECTION, value)
+    }
+
     /// Create an Accept header
     #[must_use]
     pub const fn accept(value: &'a str) -> Self {
@@ -86,6 +100,12 @@ impl<'a> HttpHeader<'a> {
     #[must_use]
     pub const fn api_key(value: &'a str) -> Self {
         Self::new(headers::X_API_KEY, value)
+    }
+
+    /// Create a Content-Type: text/event-stream header
+    #[must_use]
+    pub const fn event_stream() -> Self {
+        Self::new(headers::CONTENT_TYPE, mime_types::EVENT_STREAM)
     }
 }
 
@@ -101,5 +121,17 @@ mod tests {
         };
         assert_eq!(header.name, "Content-Type");
         assert_eq!(header.value, "application/json");
+
+        let cache = HttpHeader::cache_control("no-cache");
+        assert_eq!(cache.name, headers::CACHE_CONTROL);
+        assert_eq!(cache.value, "no-cache");
+
+        let connection = HttpHeader::connection("keep-alive");
+        assert_eq!(connection.name, headers::CONNECTION);
+        assert_eq!(connection.value, "keep-alive");
+
+        let event_stream = HttpHeader::event_stream();
+        assert_eq!(event_stream.name, headers::CONTENT_TYPE);
+        assert_eq!(event_stream.value, mime_types::EVENT_STREAM);
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -122,17 +122,43 @@ impl HttpResponse<'_> {
         &self,
     ) -> Result<Vec<u8, MAX_RESPONSE_SIZE>, Error> {
         let mut bytes = Vec::new();
+        self.write_head_bytes::<MAX_RESPONSE_SIZE>(&mut bytes, true)?;
+        push_slice(&mut bytes, self.body.as_bytes())?;
 
+        Ok(bytes)
+    }
+
+    /// Build HTTP response bytes without the body.
+    ///
+    /// This is useful for streaming endpoints that need to send headers first
+    /// and then keep the connection open for later writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if the response exceeds `MAX_RESPONSE_SIZE`.
+    pub fn build_head_bytes<const MAX_RESPONSE_SIZE: usize>(
+        &self,
+    ) -> Result<Vec<u8, MAX_RESPONSE_SIZE>, Error> {
+        let mut bytes = Vec::new();
+        self.write_head_bytes::<MAX_RESPONSE_SIZE>(&mut bytes, false)?;
+        Ok(bytes)
+    }
+
+    fn write_head_bytes<const MAX_RESPONSE_SIZE: usize>(
+        &self,
+        bytes: &mut Vec<u8, MAX_RESPONSE_SIZE>,
+        include_auto_content_length: bool,
+    ) -> Result<(), Error> {
         // Status line: HTTP/1.1 <code> <reason>\r\n
-        write_status_line(&mut bytes, self.status_code)?;
+        write_status_line(bytes, self.status_code)?;
 
         // Headers
         let mut has_content_length = false;
         for header in &self.headers {
-            push_slice(&mut bytes, header.name.as_bytes())?;
-            push_slice(&mut bytes, HEADER_SEPARATOR.as_bytes())?;
-            push_slice(&mut bytes, header.value.as_bytes())?;
-            push_slice(&mut bytes, CRLF)?;
+            push_slice(bytes, header.name.as_bytes())?;
+            push_slice(bytes, HEADER_SEPARATOR.as_bytes())?;
+            push_slice(bytes, header.value.as_bytes())?;
+            push_slice(bytes, CRLF)?;
             if header.name.eq_ignore_ascii_case(CONTENT_LENGTH) {
                 has_content_length = true;
             }
@@ -140,20 +166,16 @@ impl HttpResponse<'_> {
 
         // Content-Length header if body is present and not already specified
         let body_bytes = self.body.as_bytes();
-        if !has_content_length && !body_bytes.is_empty() {
-            push_slice(&mut bytes, CONTENT_LENGTH.as_bytes())?;
-            push_slice(&mut bytes, HEADER_SEPARATOR.as_bytes())?;
-            write_decimal_to_buffer(&mut bytes, body_bytes.len())?;
-            push_slice(&mut bytes, CRLF)?;
+        if include_auto_content_length && !has_content_length && !body_bytes.is_empty() {
+            push_slice(bytes, CONTENT_LENGTH.as_bytes())?;
+            push_slice(bytes, HEADER_SEPARATOR.as_bytes())?;
+            write_decimal_to_buffer(bytes, body_bytes.len())?;
+            push_slice(bytes, CRLF)?;
         }
 
         // End of headers
-        push_slice(&mut bytes, CRLF)?;
-
-        // Body
-        push_slice(&mut bytes, body_bytes)?;
-
-        Ok(bytes)
+        push_slice(bytes, CRLF)?;
+        Ok(())
     }
 }
 
@@ -323,6 +345,30 @@ mod tests {
         // Check that content-length is correct
         let response_str = core::str::from_utf8(&bytes[..bytes.len() - binary_data.len()]).unwrap();
         assert!(response_str.contains("Content-Length: 4\r\n"));
+    }
+
+    #[test]
+    fn test_build_head_bytes_omits_body_and_auto_content_length() {
+        let mut headers = Vec::new();
+        let _ = headers.push(HttpHeader::event_stream());
+        let _ = headers.push(HttpHeader::cache_control("no-cache"));
+        let _ = headers.push(HttpHeader::connection("keep-alive"));
+
+        let response = HttpResponse {
+            status_code: StatusCode::Ok,
+            headers,
+            body: ResponseBody::Text("event: ping\ndata: hello\n\n"),
+        };
+
+        let bytes = response.build_head_bytes::<4096>().unwrap();
+        let response_str = core::str::from_utf8(&bytes).unwrap();
+
+        assert!(response_str.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(response_str.contains("Content-Type: text/event-stream\r\n"));
+        assert!(response_str.contains("Cache-Control: no-cache\r\n"));
+        assert!(response_str.contains("Connection: keep-alive\r\n"));
+        assert!(!response_str.contains("Content-Length"));
+        assert!(response_str.ends_with("\r\n\r\n"));
     }
 
     #[test]


### PR DESCRIPTION
### Added

- SSE-friendly header helpers for `text/event-stream`, `Cache-Control`, and `Connection`.
- `HttpResponse::build_head_bytes` for header-only responses, which makes streaming endpoints easier to wire up in embedded handlers. 