### PR TITLE
feat: add HttpResponse convenience constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.8] - 2026-06-03
+
+### Added
+
+- Convenience constructors on `HttpResponse` for common response patterns:
+  - `HttpResponse::json(body)` — 200 OK with `Content-Type: application/json`
+  - `HttpResponse::text(body)` — 200 OK with `Content-Type: text/plain`
+  - `HttpResponse::not_found()` — 404 Not Found with `Content-Type: text/plain`
+  - `HttpResponse::bad_request(body)` — 400 Bad Request with `Content-Type: text/plain`
+
 ## [0.11.7] - 2026-06-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanofish"
-version = "0.11.7"
+version = "0.11.8"
 edition = "2024"
 rust-version = "1.91"
 description = "🐟 A lightweight, `no_std` HTTP client and server for embedded systems built on top of Embassy networking."

--- a/README.md
+++ b/README.md
@@ -33,24 +33,24 @@ Nanofish is designed for embedded systems with limited memory. It provides a sim
 ### Basic HTTP Support (Default)
 ```toml
 [dependencies]
-nanofish = "0.11.7"
+nanofish = "0.11.8"
 ```
 
 ### With TLS/HTTPS Support
 ```toml
 [dependencies]
-nanofish = { version = "0.11.7", features = ["tls"] }
+nanofish = { version = "0.11.8", features = ["tls"] }
 ```
 
 ### With Logging
 ```toml
 # Using defmt (common in embedded/probe-based workflows)
 [dependencies]
-nanofish = { version = "0.11.7", features = ["defmt"] }
+nanofish = { version = "0.11.8", features = ["defmt"] }
 
 # Using the log crate (common in std or defmt-incompatible environments)
 [dependencies]
-nanofish = { version = "0.11.7", features = ["log"] }
+nanofish = { version = "0.11.8", features = ["log"] }
 ```
 
 > **Note:** The `defmt` and `log` features are **mutually exclusive**. Enabling both will produce a compile-time error. If neither is enabled, all logging calls are compiled away to no-ops.
@@ -100,7 +100,7 @@ async fn example(stack: &Stack<'_>) -> Result<(), nanofish::Error> {
     let client = DefaultHttpClient::new(stack);
     let mut response_buffer = [0u8; 8192];
     let headers = [
-        HttpHeader::user_agent("Nanofish/0.11.7"),
+        HttpHeader::user_agent("Nanofish/0.11.8"),
         HttpHeader::content_type(mime_types::JSON),
         HttpHeader::authorization("Bearer token123"),
     ];
@@ -376,6 +376,36 @@ async fn run_server(stack: Stack<'_>) -> Result<(), nanofish::Error> {
     server.serve(stack, handler).await;
 }
 ```
+
+### Response Convenience Constructors
+
+Nanofish provides associated functions on `HttpResponse` for the most common response patterns, so you don't have to manually build headers for every endpoint:
+
+```rust,ignore
+use nanofish::{HttpResponse, HttpHandler, HttpRequest};
+
+struct ApiHandler;
+
+impl HttpHandler for ApiHandler {
+    async fn handle_request(&self, request: &HttpRequest<'_>) -> Result<HttpResponse<'_>, nanofish::Error> {
+        match request.path {
+            "/api/health" => HttpResponse::json(r#"{"status":"ok"}"#),
+            "/"           => HttpResponse::text("Hello from nanofish!"),
+            "/bad"        => HttpResponse::bad_request("missing parameter"),
+            _             => HttpResponse::not_found(),
+        }
+    }
+}
+```
+
+| Constructor | Status | Content-Type | Use case |
+|-------------|--------|--------------|----------|
+| `HttpResponse::json(body)` | 200 OK | `application/json` | API endpoints |
+| `HttpResponse::text(body)` | 200 OK | `text/plain` | Simple text responses |
+| `HttpResponse::not_found()` | 404 | `text/plain` | Missing resources |
+| `HttpResponse::bad_request(body)` | 400 | `text/plain` | Invalid input |
+
+All constructors return `Result<HttpResponse<'_>, Error>` and will fail with `Error::BufferOverflow` only if the headers vector (capacity `MAX_HEADERS = 16`) is exhausted.
 
 ### Server Memory Configuration
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -2,6 +2,7 @@ use crate::{
     HttpHeader, StatusCode,
     error::Error,
     header::headers::{CONTENT_LENGTH, CONTENT_TYPE},
+    header::mime_types,
     protocol::{CRLF, HEADER_SEPARATOR, HTTP_VERSION_PREFIX, MAX_HEADERS},
 };
 use heapless::Vec;
@@ -73,7 +74,7 @@ pub struct HttpResponse<'a> {
     pub body: ResponseBody<'a>,
 }
 
-impl HttpResponse<'_> {
+impl<'a> HttpResponse<'a> {
     /// Get a header value by name (case-insensitive)
     #[must_use]
     pub fn get_header(&self, name: &str) -> Option<&str> {
@@ -111,6 +112,74 @@ impl HttpResponse<'_> {
     #[must_use]
     pub fn is_server_error(&self) -> bool {
         self.status_code.is_server_error()
+    }
+
+    /// Create a 200 OK JSON response.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if the headers buffer is full.
+    pub fn json(body: &'a str) -> Result<Self, Error> {
+        let mut headers = Vec::new();
+        headers
+            .push(HttpHeader::content_type(mime_types::JSON))
+            .map_err(|_| Error::BufferOverflow)?;
+        Ok(Self {
+            status_code: StatusCode::Ok,
+            headers,
+            body: ResponseBody::Text(body),
+        })
+    }
+
+    /// Create a 200 OK plain-text response.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if the headers buffer is full.
+    pub fn text(body: &'a str) -> Result<Self, Error> {
+        let mut headers = Vec::new();
+        headers
+            .push(HttpHeader::content_type(mime_types::TEXT))
+            .map_err(|_| Error::BufferOverflow)?;
+        Ok(Self {
+            status_code: StatusCode::Ok,
+            headers,
+            body: ResponseBody::Text(body),
+        })
+    }
+
+    /// Create a 404 Not Found plain-text response.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if the headers buffer is full.
+    pub fn not_found() -> Result<Self, Error> {
+        let mut headers = Vec::new();
+        headers
+            .push(HttpHeader::content_type(mime_types::TEXT))
+            .map_err(|_| Error::BufferOverflow)?;
+        Ok(Self {
+            status_code: StatusCode::NotFound,
+            headers,
+            body: ResponseBody::Text("Not Found"),
+        })
+    }
+
+    /// Create a 400 Bad Request plain-text response.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if the headers buffer is full.
+    pub fn bad_request(body: &'a str) -> Result<Self, Error> {
+        let mut headers = Vec::new();
+        headers
+            .push(HttpHeader::content_type(mime_types::TEXT))
+            .map_err(|_| Error::BufferOverflow)?;
+        Ok(Self {
+            status_code: StatusCode::BadRequest,
+            headers,
+            body: ResponseBody::Text(body),
+        })
     }
 
     /// Build HTTP response bytes from this `HttpResponse`


### PR DESCRIPTION
Adds associated functions for the most common response patterns, removing boilerplate from handlers:

- `HttpResponse::json(body)` — 200 OK + application/json
- `HttpResponse::text(body)` — 200 OK + text/plain  
- `HttpResponse::not_found()` — 404 + text/plain
- `HttpResponse::bad_request(body)` — 400 + text/plain

All constructors return `Result<..., Error>` and fail only if the 16-slot headers buffer is exhausted.

CHANGELOG and README updated. Patch bump 0.11.7 → 0.11.8.