### PR TITLE
chore: add git governance

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Pre-push hook: prevents direct pushes to main
+
+protected_branch="main"
+current_branch=$(git symbolic-ref --short HEAD)
+
+if [ "$current_branch" = "$protected_branch" ]; then
+    echo "Error: direct push to '$protected_branch' is not allowed."
+    echo "Create a feature branch and open a pull request instead."
+    echo ""
+    echo "  git checkout -b feat/your-change"
+    echo "  git push origin feat/your-change"
+    echo "  gh pr create --base main"
+    exit 1
+fi
+
+exit 0

--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -1,0 +1,25 @@
+name: "Branch Naming"
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        run: |
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          echo "Checking branch: $BRANCH"
+          if [[ "$BRANCH" =~ ^(feat|fix|chore|docs|refactor|test|release)/.+$ ]]; then
+            echo "Branch name is valid"
+          else
+            echo "Error: Branch name '$BRANCH' does not match required pattern"
+            echo "Expected format: <type>/<short-description>"
+            echo "Allowed types: feat, fix, chore, docs, refactor, test, release"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to nanofish
+
+## Git Workflow
+
+### Protected Main
+
+- **`main` is protected** — never push directly to `main`.
+- All changes must go through a pull request.
+- PRs require CI to pass before merge.
+
+### Branch Naming
+
+All branches must follow the pattern:
+
+```
+<type>/<short-description>
+```
+
+**Allowed types:**
+- `feat` — new features
+- `fix` — bug fixes
+- `chore` — maintenance, dependencies, tooling
+- `docs` — documentation only
+- `refactor` — code restructuring without functional change
+- `test` — adding or updating tests
+- `release` — version bumps and release prep
+
+**Examples:**
+- `feat/response-constructors`
+- `fix/header-parsing`
+- `chore/bump-embassy-net`
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+
+<body>
+```
+
+**Types:** `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`
+
+### CI Requirements
+
+All PRs must pass:
+- `cargo fmt` check
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- Branch naming validation
+
+### Releasing
+
+1. Update `CHANGELOG.md` under `[Unreleased]`
+2. Bump version in `Cargo.toml`
+3. Create a `release/vX.Y.Z` branch
+4. Open PR, merge to `main`
+5. Tag `main` with `vX.Y.Z`
+6. Push tag (triggers release workflow)

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ RUST_VERSION := $(shell grep 'rust-version = ' Cargo.toml | head -1 | sed 's/.*r
 
 FEATURES ?=
 
+.PHONY: install-hooks
+install-hooks: ## Install git hooks (prevents direct push to main)
+	git config core.hooksPath .githooks
+	@echo "Git hooks installed from .githooks/"
+
 .PHONY: install-rust
 install-rust: ## Install Rust toolchain with required components
 	rustup toolchain install $(RUST_VERSION)


### PR DESCRIPTION
Adds workflow rules to prevent direct pushes to main and enforce branch naming conventions.

- **CONTRIBUTING.md** — documents protected main, branch naming format, commit message style, and CI requirements
- **.github/workflows/branch-naming.yml** — CI check that rejects branches not matching `feat|fix|chore|docs|refactor|test|release/*`
- **.githooks/pre-push** — local hook that blocks `git push origin main` with a helpful error message
- **Makefile** — adds `make install-hooks` to wire up .githooks/