### PR TITLE
refactor: yank 0.11.8, introduce HttpResponseBuilder (v0.11.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.8] - 2026-06-03
+## [0.11.9] - TBD
 
 ### Added
 
-- Convenience constructors on `HttpResponse` for common response patterns:
-  - `HttpResponse::json(body)` — 200 OK with `Content-Type: application/json`
-  - `HttpResponse::text(body)` — 200 OK with `Content-Type: text/plain`
-  - `HttpResponse::not_found()` — 404 Not Found with `Content-Type: text/plain`
-  - `HttpResponse::bad_request(body)` — 400 Bad Request with `Content-Type: text/plain`
+- `HttpResponseBuilder` with fluent API for flexible response construction:
+  - Chainable methods: `status()`, `header()`, `headers()`, `content_type()`
+  - Smart body builders: `text()`, `binary()`, `empty_body()`
+  - Auto Content-Type detection based on body type (unless manually set)
+  - JSON is just text - use `.content_type(mime_types::JSON).text(body)`
+  - RFC 7807 Problem Details support via `mime_types::PROBLEM_JSON`
+- `mime_types::PROBLEM_JSON` constant for RFC 7807 Problem Details for HTTP APIs
+
+### Removed
+
+- ❌ **YANKED**: v0.11.8 convenience constructors (`json()`, `text()`, `not_found()`, `bad_request()`) - poorly designed, too opinionated
+  - `json()` was hardcoded to 200 OK (invalid for error responses)
+  - `bad_request()` was hardcoded to `text/plain` (invalid for RFC 7807 JSON errors)
+  - Not flexible enough for real-world API patterns
+
+### Migration Guide (from 0.11.8)
+
+**Before (removed):**
+```rust,ignore
+HttpResponse::json(r#"{"status":"ok"}"#)          // ❌ hardcoded 200
+HttpResponse::bad_request("missing parameter")    // ❌ hardcoded text/plain
+```
+
+**After (builder):**
+```rust,ignore
+// Success with JSON
+HttpResponseBuilder::new()
+    .content_type(mime_types::JSON)
+    .text(r#"{"status":"ok"}"#)
+    .build()?
+
+// RFC 7807 Problem Details (JSON error)
+HttpResponseBuilder::new()
+    .status(StatusCode::BadRequest)
+    .content_type(mime_types::PROBLEM_JSON)
+    .text(r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#)
+    .build()?
+
+// Simple text response (auto Content-Type: text/plain)
+HttpResponseBuilder::new()
+    .status(StatusCode::NotFound)
+    .text("Not Found")
+    .build()?
+```
+
+## [0.11.8] - YANKED (2026-06-03)
+
+**Yanked due to poorly designed convenience constructors.** See v0.11.9 for replacement builder pattern.
 
 ## [0.11.7] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `HttpResponseBuilder` with fluent API for flexible response construction:
   - Chainable methods: `status()`, `header()`, `headers()`, `content_type()`
-  - Smart body builders: `text()`, `binary()`, `empty_body()`
-  - Auto Content-Type detection based on body type (unless manually set)
-  - JSON is just text - use `.content_type(mime_types::JSON).text(body)`
-  - RFC 7807 Problem Details support via `mime_types::PROBLEM_JSON`
+  - Body methods: `text()`, `binary()`, `empty_body()`
+  - Shortcut methods: `json(body)` (sets `Content-Type: application/json` + text body), `problem_json(body)` (sets `Content-Type: application/problem+json` + text body for RFC 7807)
+  - `build()` returns `HttpResponse` (infallible — errors surface from `header`/`json`/etc calls)
 - `mime_types::PROBLEM_JSON` constant for RFC 7807 Problem Details for HTTP APIs
 
 ### Removed
@@ -36,24 +35,19 @@ HttpResponse::bad_request("missing parameter")    // ❌ hardcoded text/plain
 
 **After (builder):**
 ```rust,ignore
-// Success with JSON
-HttpResponseBuilder::new()
-    .content_type(mime_types::JSON)
-    .text(r#"{"status":"ok"}"#)
-    .build()?
+// JSON success
+HttpResponseBuilder::new().json(r#"{"status":"ok"}"#)?
 
-// RFC 7807 Problem Details (JSON error)
+// JSON error (RFC 7807)
 HttpResponseBuilder::new()
     .status(StatusCode::BadRequest)
-    .content_type(mime_types::PROBLEM_JSON)
-    .text(r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#)
-    .build()?
+    .problem_json(r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#)?
 
-// Simple text response (auto Content-Type: text/plain)
+// Text with custom Content-Type
 HttpResponseBuilder::new()
     .status(StatusCode::NotFound)
+    .content_type(mime_types::TEXT)?
     .text("Not Found")
-    .build()?
 ```
 
 ## [0.11.8] - YANKED (2026-06-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `HttpResponseBuilder` with fluent API for flexible response construction:
-  - Chainable methods: `status()`, `header()`, `headers()`, `content_type()`
-  - Body methods: `text()`, `binary()`, `empty_body()`
-  - Shortcut methods: `json(body)` (sets `Content-Type: application/json` + text body), `problem_json(body)` (sets `Content-Type: application/problem+json` + text body for RFC 7807)
-  - `build()` returns `HttpResponse` (infallible — errors surface from `header`/`json`/etc calls)
+  - `status(code)` — set HTTP status
+  - `header(name, value)` / `headers(&[hdr])` — add custom headers
+  - `content_type(ct)` — set Content-Type header
+  - `json(body)` — sets `Content-Type: application/json` + text body
+  - `problem_json(body)` — sets `Content-Type: application/problem+json` + text body (RFC 7807)
+  - `text(body)` / `binary(data)` / `empty_body()` — set body
+  - `build()` → `Result<HttpResponse>` — builds with header dedup (last value wins)
 - `mime_types::PROBLEM_JSON` constant for RFC 7807 Problem Details for HTTP APIs
 
 ### Removed
@@ -36,18 +39,20 @@ HttpResponse::bad_request("missing parameter")    // ❌ hardcoded text/plain
 **After (builder):**
 ```rust,ignore
 // JSON success
-HttpResponseBuilder::new().json(r#"{"status":"ok"}"#)?
+HttpResponseBuilder::new().json(r#"{"status":"ok"}"#)?.build()?
 
 // JSON error (RFC 7807)
 HttpResponseBuilder::new()
     .status(StatusCode::BadRequest)
     .problem_json(r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#)?
+    .build()?
 
 // Text with custom Content-Type
 HttpResponseBuilder::new()
     .status(StatusCode::NotFound)
     .content_type(mime_types::TEXT)?
     .text("Not Found")
+    .build()?
 ```
 
 ## [0.11.8] - YANKED (2026-06-03)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanofish"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2024"
 rust-version = "1.91"
 description = "🐟 A lightweight, `no_std` HTTP client and server for embedded systems built on top of Embassy networking."

--- a/README.md
+++ b/README.md
@@ -377,35 +377,48 @@ async fn run_server(stack: Stack<'_>) -> Result<(), nanofish::Error> {
 }
 ```
 
-### Response Convenience Constructors
+### Response Builder
 
-Nanofish provides associated functions on `HttpResponse` for the most common response patterns, so you don't have to manually build headers for every endpoint:
+Use `HttpResponseBuilder` to construct responses with a fluent API:
 
 ```rust,ignore
-use nanofish::{HttpResponse, HttpHandler, HttpRequest};
+use nanofish::{HttpResponseBuilder, HttpHandler, HttpRequest, StatusCode, mime_types};
 
 struct ApiHandler;
 
 impl HttpHandler for ApiHandler {
     async fn handle_request(&self, request: &HttpRequest<'_>) -> Result<HttpResponse<'_>, nanofish::Error> {
         match request.path {
-            "/api/health" => HttpResponse::json(r#"{"status":"ok"}"#),
-            "/"           => HttpResponse::text("Hello from nanofish!"),
-            "/bad"        => HttpResponse::bad_request("missing parameter"),
-            _             => HttpResponse::not_found(),
+            "/api/health" => HttpResponseBuilder::new().json(r#"{"status":"ok"}"#)?.build()?,
+            "/"           => HttpResponseBuilder::new()
+                                .content_type(mime_types::TEXT)?
+                                .text("Hello from nanofish!")
+                                .build()?,
+            "/bad"        => HttpResponseBuilder::new()
+                                .status(StatusCode::BadRequest)
+                                .problem_json(r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#)?
+                                .build()?,
+            _             => HttpResponseBuilder::new()
+                                .status(StatusCode::NotFound)
+                                .content_type(mime_types::TEXT)?
+                                .text("Not Found")
+                                .build()?,
         }
     }
 }
 ```
 
-| Constructor | Status | Content-Type | Use case |
-|-------------|--------|--------------|----------|
-| `HttpResponse::json(body)` | 200 OK | `application/json` | API endpoints |
-| `HttpResponse::text(body)` | 200 OK | `text/plain` | Simple text responses |
-| `HttpResponse::not_found()` | 404 | `text/plain` | Missing resources |
-| `HttpResponse::bad_request(body)` | 400 | `text/plain` | Invalid input |
-
-All constructors return `Result<HttpResponse<'_>, Error>` and will fail with `Error::BufferOverflow` only if the headers vector (capacity `MAX_HEADERS = 16`) is exhausted.
+| Method | Description |
+|--------|-------------|
+| `status(code)` | Set HTTP status |
+| `content_type(ct)` | Set Content-Type header |
+| `json(body)` | Content-Type: application/json + text body |
+| `problem_json(body)` | Content-Type: application/problem+json + text body (RFC 7807) |
+| `text(body)` | Set text body |
+| `binary(data)` | Set binary body |
+| `empty_body()` | Set empty body |
+| `header(name, value)` | Add custom header |
+| `build()` → `Result<HttpResponse>` | Build with header dedup (last wins) |
 
 ### Server Memory Configuration
 

--- a/README.md
+++ b/README.md
@@ -33,24 +33,24 @@ Nanofish is designed for embedded systems with limited memory. It provides a sim
 ### Basic HTTP Support (Default)
 ```toml
 [dependencies]
-nanofish = "0.11.8"
+nanofish = "0.11.9"
 ```
 
 ### With TLS/HTTPS Support
 ```toml
 [dependencies]
-nanofish = { version = "0.11.8", features = ["tls"] }
+nanofish = { version = "0.11.9", features = ["tls"] }
 ```
 
 ### With Logging
 ```toml
 # Using defmt (common in embedded/probe-based workflows)
 [dependencies]
-nanofish = { version = "0.11.8", features = ["defmt"] }
+nanofish = { version = "0.11.9", features = ["defmt"] }
 
 # Using the log crate (common in std or defmt-incompatible environments)
 [dependencies]
-nanofish = { version = "0.11.8", features = ["log"] }
+nanofish = { version = "0.11.9", features = ["log"] }
 ```
 
 > **Note:** The `defmt` and `log` features are **mutually exclusive**. Enabling both will produce a compile-time error. If neither is enabled, all logging calls are compiled away to no-ops.
@@ -100,7 +100,7 @@ async fn example(stack: &Stack<'_>) -> Result<(), nanofish::Error> {
     let client = DefaultHttpClient::new(stack);
     let mut response_buffer = [0u8; 8192];
     let headers = [
-        HttpHeader::user_agent("Nanofish/0.11.8"),
+        HttpHeader::user_agent("Nanofish/0.11.9"),
         HttpHeader::content_type(mime_types::JSON),
         HttpHeader::authorization("Bearer token123"),
     ];

--- a/src/header.rs
+++ b/src/header.rs
@@ -26,6 +26,8 @@ pub mod headers {
 pub mod mime_types {
     /// application/json
     pub const JSON: &str = "application/json";
+    /// application/problem+json (RFC 7807 Problem Details)
+    pub const PROBLEM_JSON: &str = "application/problem+json";
     /// application/xml
     pub const XML: &str = "application/xml";
     /// text/plain

--- a/src/response.rs
+++ b/src/response.rs
@@ -190,30 +190,29 @@ impl HttpResponse<'_> {
 /// // JSON success response
 /// let response = HttpResponseBuilder::new()
 ///     .status(StatusCode::Ok)
-///     .content_type(mime_types::JSON)
-///     .text(r#"{"status":"ok"}"#)
-///     .build()?;
+///     .json(r#"{"status":"ok"}"#)?;
 ///
 /// // JSON error response (RFC 7807 Problem Details)
 /// let response = HttpResponseBuilder::new()
 ///     .status(StatusCode::BadRequest)
-///     .content_type(mime_types::PROBLEM_JSON)
-///     .text(r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#)
-///     .header(headers::CACHE_CONTROL, "no-cache")
-///     .build()?;
+///     .problem_json(r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#)?;
+///
+/// // Plain text with custom Content-Type
+/// let response = HttpResponseBuilder::new()
+///     .status(StatusCode::NotFound)
+///     .content_type(mime_types::TEXT)?
+///     .text("Not Found");
 ///
 /// // Binary response
 /// let response = HttpResponseBuilder::new()
 ///     .status(StatusCode::Ok)
-///     .content_type(mime_types::BINARY)
-///     .binary(&[0x00, 0x01, 0x02])
-///     .build()?;
+///     .content_type(mime_types::BINARY)?
+///     .binary(&[0x00, 0x01, 0x02]);
 /// ```
 pub struct HttpResponseBuilder<'a> {
     status: StatusCode,
     headers: Vec<HttpHeader<'a>, MAX_HEADERS>,
     body: Option<ResponseBody<'a>>,
-    auto_content_type: bool,
 }
 
 impl<'a> HttpResponseBuilder<'a> {
@@ -224,7 +223,6 @@ impl<'a> HttpResponseBuilder<'a> {
             status: StatusCode::Ok,
             headers: Vec::new(),
             body: None,
-            auto_content_type: true,
         }
     }
 
@@ -235,7 +233,6 @@ impl<'a> HttpResponseBuilder<'a> {
             status,
             headers: Vec::new(),
             body: None,
-            auto_content_type: true,
         }
     }
 
@@ -281,18 +278,43 @@ impl<'a> HttpResponseBuilder<'a> {
         self.headers
             .push(HttpHeader::content_type(ct))
             .map_err(|_| Error::BufferOverflow)?;
-        self.auto_content_type = false;
         Ok(self)
     }
 
-    /// Set text body (auto-sets Content-Type: text/plain if not already set)
+    /// Set JSON body with `Content-Type: application/json`
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if headers buffer is full.
+    pub fn json(mut self, body: &'a str) -> Result<Self, Error> {
+        self.headers
+            .push(HttpHeader::content_type(mime_types::JSON))
+            .map_err(|_| Error::BufferOverflow)?;
+        self.body = Some(ResponseBody::Text(body));
+        Ok(self)
+    }
+
+    /// Set JSON body with `Content-Type: application/problem+json` (RFC 7807)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if headers buffer is full.
+    pub fn problem_json(mut self, body: &'a str) -> Result<Self, Error> {
+        self.headers
+            .push(HttpHeader::content_type(mime_types::PROBLEM_JSON))
+            .map_err(|_| Error::BufferOverflow)?;
+        self.body = Some(ResponseBody::Text(body));
+        Ok(self)
+    }
+
+    /// Set text body
     #[must_use]
     pub const fn text(mut self, body: &'a str) -> Self {
         self.body = Some(ResponseBody::Text(body));
         self
     }
 
-    /// Set binary body (caller should set Content-Type via `content_type()`)
+    /// Set binary body
     #[must_use]
     pub const fn binary(mut self, body: &'a [u8]) -> Self {
         self.body = Some(ResponseBody::Binary(body));
@@ -307,28 +329,13 @@ impl<'a> HttpResponseBuilder<'a> {
     }
 
     /// Construct the final `HttpResponse`
-    ///
-    /// # Errors
-    ///
-    /// Returns `Error::BufferOverflow` if headers buffer is full.
-    #[allow(clippy::unnested_or_patterns)]
-    pub fn build(mut self) -> Result<HttpResponse<'a>, Error> {
-        // Auto-add Content-Type based on body type if not already set
-        if self.auto_content_type {
-            let ct = match &self.body {
-                Some(ResponseBody::Binary(_)) => mime_types::BINARY,
-                Some(ResponseBody::Text(_)) | Some(ResponseBody::Empty) | None => mime_types::TEXT,
-            };
-            self.headers
-                .push(HttpHeader::content_type(ct))
-                .map_err(|_| Error::BufferOverflow)?;
-        }
-
-        Ok(HttpResponse {
+    #[must_use]
+    pub fn build(self) -> HttpResponse<'a> {
+        HttpResponse {
             status_code: self.status,
             headers: self.headers,
             body: self.body.unwrap_or(ResponseBody::Empty),
-        })
+        }
     }
 }
 
@@ -615,31 +622,26 @@ mod tests {
 
     #[test]
     fn test_builder_default_ok_empty() {
-        let response = HttpResponseBuilder::new().build().unwrap();
+        let response = HttpResponseBuilder::new().build();
         assert_eq!(response.status_code, StatusCode::Ok);
         assert_eq!(response.body, ResponseBody::Empty);
-        assert_eq!(response.get_header("Content-Type"), Some("text/plain"));
     }
 
     #[test]
-    fn test_builder_text_success() {
+    fn test_builder_text() {
         let response = HttpResponseBuilder::new()
             .text(r#"{"status":"ok"}"#)
-            .build()
-            .unwrap();
+            .build();
         assert_eq!(response.status_code, StatusCode::Ok);
         assert_eq!(response.body, ResponseBody::Text(r#"{"status":"ok"}"#));
-        assert_eq!(response.get_header("Content-Type"), Some("text/plain"));
     }
 
     #[test]
-    fn test_builder_json_with_explicit_content_type() {
+    fn test_builder_json() {
         let response = HttpResponseBuilder::new()
-            .content_type(mime_types::JSON)
+            .json(r#"{"status":"ok"}"#)
             .unwrap()
-            .text(r#"{"status":"ok"}"#)
-            .build()
-            .unwrap();
+            .build();
         assert_eq!(response.status_code, StatusCode::Ok);
         assert_eq!(
             response.get_header("Content-Type"),
@@ -648,14 +650,14 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_rfc7807_problem_details() {
+    fn test_builder_problem_json() {
         let response = HttpResponseBuilder::new()
             .status(StatusCode::BadRequest)
-            .content_type(mime_types::PROBLEM_JSON)
+            .problem_json(
+                r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#,
+            )
             .unwrap()
-            .text(r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#)
-            .build()
-            .unwrap();
+            .build();
         assert_eq!(response.status_code, StatusCode::BadRequest);
         assert_eq!(
             response.get_header("Content-Type"),
@@ -664,12 +666,13 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_text() {
+    fn test_builder_text_with_content_type() {
         let response = HttpResponseBuilder::new()
             .status(StatusCode::NotFound)
+            .content_type(mime_types::TEXT)
+            .unwrap()
             .text("Not Found")
-            .build()
-            .unwrap();
+            .build();
         assert_eq!(response.status_code, StatusCode::NotFound);
         assert_eq!(response.body, ResponseBody::Text("Not Found"));
         assert_eq!(response.get_header("Content-Type"), Some("text/plain"));
@@ -682,8 +685,7 @@ mod tests {
             .content_type(mime_types::BINARY)
             .unwrap()
             .binary(data)
-            .build()
-            .unwrap();
+            .build();
         assert_eq!(response.status_code, StatusCode::Ok);
         assert_eq!(response.body, ResponseBody::Binary(data));
         assert_eq!(
@@ -700,8 +702,7 @@ mod tests {
             .header(headers::CACHE_CONTROL, "no-cache")
             .unwrap()
             .text("ok")
-            .build()
-            .unwrap();
+            .build();
         assert_eq!(response.get_header("X-Custom-Header"), Some("custom-value"));
         assert_eq!(response.get_header("Cache-Control"), Some("no-cache"));
     }
@@ -710,8 +711,7 @@ mod tests {
     fn test_builder_status_override() {
         let response = HttpResponseBuilder::with_status(StatusCode::Created)
             .text("Created")
-            .build()
-            .unwrap();
+            .build();
         assert_eq!(response.status_code, StatusCode::Created);
     }
 
@@ -720,8 +720,7 @@ mod tests {
         let response = HttpResponseBuilder::new()
             .status(StatusCode::NoContent)
             .empty_body()
-            .build()
-            .unwrap();
+            .build();
         assert_eq!(response.status_code, StatusCode::NoContent);
         assert_eq!(response.body, ResponseBody::Empty);
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -329,13 +329,35 @@ impl<'a> HttpResponseBuilder<'a> {
     }
 
     /// Construct the final `HttpResponse`
-    #[must_use]
-    pub fn build(self) -> HttpResponse<'a> {
-        HttpResponse {
+    ///
+    /// Deduplicates headers by name — the last set value wins.
+    ///
+    /// # Errors
+    ///
+    /// Currently always returns `Ok`, but returns `Result` for future-proofing.
+    pub fn build(self) -> Result<HttpResponse<'a>, Error> {
+        let mut headers = self.headers;
+        // Deduplicate: keep last occurrence of each header name
+        headers = headers.into_iter().rev().fold(
+            Vec::new(),
+            |mut acc: Vec<HttpHeader<'a>, MAX_HEADERS>, h| {
+                if !acc
+                    .iter()
+                    .any(|existing| existing.name.eq_ignore_ascii_case(h.name))
+                {
+                    let _ = acc.push(h);
+                }
+                acc
+            },
+        );
+        // Restore original order
+        headers.reverse();
+
+        Ok(HttpResponse {
             status_code: self.status,
-            headers: self.headers,
+            headers,
             body: self.body.unwrap_or(ResponseBody::Empty),
-        }
+        })
     }
 }
 
@@ -622,7 +644,7 @@ mod tests {
 
     #[test]
     fn test_builder_default_ok_empty() {
-        let response = HttpResponseBuilder::new().build();
+        let response = HttpResponseBuilder::new().build().unwrap();
         assert_eq!(response.status_code, StatusCode::Ok);
         assert_eq!(response.body, ResponseBody::Empty);
     }
@@ -631,7 +653,8 @@ mod tests {
     fn test_builder_text() {
         let response = HttpResponseBuilder::new()
             .text(r#"{"status":"ok"}"#)
-            .build();
+            .build()
+            .unwrap();
         assert_eq!(response.status_code, StatusCode::Ok);
         assert_eq!(response.body, ResponseBody::Text(r#"{"status":"ok"}"#));
     }
@@ -641,7 +664,8 @@ mod tests {
         let response = HttpResponseBuilder::new()
             .json(r#"{"status":"ok"}"#)
             .unwrap()
-            .build();
+            .build()
+            .unwrap();
         assert_eq!(response.status_code, StatusCode::Ok);
         assert_eq!(
             response.get_header("Content-Type"),
@@ -657,7 +681,8 @@ mod tests {
                 r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#,
             )
             .unwrap()
-            .build();
+            .build()
+            .unwrap();
         assert_eq!(response.status_code, StatusCode::BadRequest);
         assert_eq!(
             response.get_header("Content-Type"),
@@ -672,7 +697,8 @@ mod tests {
             .content_type(mime_types::TEXT)
             .unwrap()
             .text("Not Found")
-            .build();
+            .build()
+            .unwrap();
         assert_eq!(response.status_code, StatusCode::NotFound);
         assert_eq!(response.body, ResponseBody::Text("Not Found"));
         assert_eq!(response.get_header("Content-Type"), Some("text/plain"));
@@ -685,7 +711,8 @@ mod tests {
             .content_type(mime_types::BINARY)
             .unwrap()
             .binary(data)
-            .build();
+            .build()
+            .unwrap();
         assert_eq!(response.status_code, StatusCode::Ok);
         assert_eq!(response.body, ResponseBody::Binary(data));
         assert_eq!(
@@ -702,7 +729,8 @@ mod tests {
             .header(headers::CACHE_CONTROL, "no-cache")
             .unwrap()
             .text("ok")
-            .build();
+            .build()
+            .unwrap();
         assert_eq!(response.get_header("X-Custom-Header"), Some("custom-value"));
         assert_eq!(response.get_header("Cache-Control"), Some("no-cache"));
     }
@@ -711,7 +739,8 @@ mod tests {
     fn test_builder_status_override() {
         let response = HttpResponseBuilder::with_status(StatusCode::Created)
             .text("Created")
-            .build();
+            .build()
+            .unwrap();
         assert_eq!(response.status_code, StatusCode::Created);
     }
 
@@ -720,8 +749,32 @@ mod tests {
         let response = HttpResponseBuilder::new()
             .status(StatusCode::NoContent)
             .empty_body()
-            .build();
+            .build()
+            .unwrap();
         assert_eq!(response.status_code, StatusCode::NoContent);
         assert_eq!(response.body, ResponseBody::Empty);
+    }
+
+    #[test]
+    fn test_builder_deduplicates_headers() {
+        let response = HttpResponseBuilder::new()
+            .content_type(mime_types::TEXT)
+            .unwrap()
+            .content_type(mime_types::JSON)
+            .unwrap()
+            .text("ok")
+            .build()
+            .unwrap();
+        assert_eq!(
+            response.get_header("Content-Type"),
+            Some("application/json")
+        );
+        // Only one Content-Type header
+        let ct_count = response
+            .headers
+            .iter()
+            .filter(|h| h.name.eq_ignore_ascii_case("Content-Type"))
+            .count();
+        assert_eq!(ct_count, 1);
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,7 +8,7 @@ use crate::{
 use heapless::Vec;
 
 /// HTTP Response body that can handle both text and binary data using zero-copy references
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum ResponseBody<'a> {
     /// Text content (UTF-8 encoded) - borrowed from the response buffer
     Text(&'a str),
@@ -74,7 +74,7 @@ pub struct HttpResponse<'a> {
     pub body: ResponseBody<'a>,
 }
 
-impl<'a> HttpResponse<'a> {
+impl HttpResponse<'_> {
     /// Get a header value by name (case-insensitive)
     #[must_use]
     pub fn get_header(&self, name: &str) -> Option<&str> {
@@ -112,74 +112,6 @@ impl<'a> HttpResponse<'a> {
     #[must_use]
     pub fn is_server_error(&self) -> bool {
         self.status_code.is_server_error()
-    }
-
-    /// Create a 200 OK JSON response.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Error::BufferOverflow` if the headers buffer is full.
-    pub fn json(body: &'a str) -> Result<Self, Error> {
-        let mut headers = Vec::new();
-        headers
-            .push(HttpHeader::content_type(mime_types::JSON))
-            .map_err(|_| Error::BufferOverflow)?;
-        Ok(Self {
-            status_code: StatusCode::Ok,
-            headers,
-            body: ResponseBody::Text(body),
-        })
-    }
-
-    /// Create a 200 OK plain-text response.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Error::BufferOverflow` if the headers buffer is full.
-    pub fn text(body: &'a str) -> Result<Self, Error> {
-        let mut headers = Vec::new();
-        headers
-            .push(HttpHeader::content_type(mime_types::TEXT))
-            .map_err(|_| Error::BufferOverflow)?;
-        Ok(Self {
-            status_code: StatusCode::Ok,
-            headers,
-            body: ResponseBody::Text(body),
-        })
-    }
-
-    /// Create a 404 Not Found plain-text response.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Error::BufferOverflow` if the headers buffer is full.
-    pub fn not_found() -> Result<Self, Error> {
-        let mut headers = Vec::new();
-        headers
-            .push(HttpHeader::content_type(mime_types::TEXT))
-            .map_err(|_| Error::BufferOverflow)?;
-        Ok(Self {
-            status_code: StatusCode::NotFound,
-            headers,
-            body: ResponseBody::Text("Not Found"),
-        })
-    }
-
-    /// Create a 400 Bad Request plain-text response.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Error::BufferOverflow` if the headers buffer is full.
-    pub fn bad_request(body: &'a str) -> Result<Self, Error> {
-        let mut headers = Vec::new();
-        headers
-            .push(HttpHeader::content_type(mime_types::TEXT))
-            .map_err(|_| Error::BufferOverflow)?;
-        Ok(Self {
-            status_code: StatusCode::BadRequest,
-            headers,
-            body: ResponseBody::Text(body),
-        })
     }
 
     /// Build HTTP response bytes from this `HttpResponse`
@@ -248,6 +180,164 @@ impl<'a> HttpResponse<'a> {
     }
 }
 
+/// Builder for constructing HTTP responses with a fluent API
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use nanofish::{HttpResponse, HttpResponseBuilder, StatusCode, headers, mime_types};
+///
+/// // JSON success response
+/// let response = HttpResponseBuilder::new()
+///     .status(StatusCode::Ok)
+///     .content_type(mime_types::JSON)
+///     .text(r#"{"status":"ok"}"#)
+///     .build()?;
+///
+/// // JSON error response (RFC 7807 Problem Details)
+/// let response = HttpResponseBuilder::new()
+///     .status(StatusCode::BadRequest)
+///     .content_type(mime_types::PROBLEM_JSON)
+///     .text(r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#)
+///     .header(headers::CACHE_CONTROL, "no-cache")
+///     .build()?;
+///
+/// // Binary response
+/// let response = HttpResponseBuilder::new()
+///     .status(StatusCode::Ok)
+///     .content_type(mime_types::BINARY)
+///     .binary(&[0x00, 0x01, 0x02])
+///     .build()?;
+/// ```
+pub struct HttpResponseBuilder<'a> {
+    status: StatusCode,
+    headers: Vec<HttpHeader<'a>, MAX_HEADERS>,
+    body: Option<ResponseBody<'a>>,
+    auto_content_type: bool,
+}
+
+impl<'a> HttpResponseBuilder<'a> {
+    /// Create a new builder with default values (200 OK, no headers, empty body)
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            status: StatusCode::Ok,
+            headers: Vec::new(),
+            body: None,
+            auto_content_type: true,
+        }
+    }
+
+    /// Create a new builder with a specific status code
+    #[must_use]
+    pub const fn with_status(status: StatusCode) -> Self {
+        Self {
+            status,
+            headers: Vec::new(),
+            body: None,
+            auto_content_type: true,
+        }
+    }
+
+    /// Set the HTTP status code
+    #[must_use]
+    pub const fn status(mut self, status: StatusCode) -> Self {
+        self.status = status;
+        self
+    }
+
+    /// Add a custom header
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if headers buffer is full.
+    pub fn header(mut self, name: &'a str, value: &'a str) -> Result<Self, Error> {
+        self.headers
+            .push(HttpHeader::new(name, value))
+            .map_err(|_| Error::BufferOverflow)?;
+        Ok(self)
+    }
+
+    /// Add multiple headers at once
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if headers buffer is full.
+    pub fn headers(mut self, headers: &[HttpHeader<'a>]) -> Result<Self, Error> {
+        for header in headers {
+            self.headers
+                .push(HttpHeader::new(header.name, header.value))
+                .map_err(|_| Error::BufferOverflow)?;
+        }
+        Ok(self)
+    }
+
+    /// Set Content-Type header
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if headers buffer is full.
+    pub fn content_type(mut self, ct: &'a str) -> Result<Self, Error> {
+        self.headers
+            .push(HttpHeader::content_type(ct))
+            .map_err(|_| Error::BufferOverflow)?;
+        self.auto_content_type = false;
+        Ok(self)
+    }
+
+    /// Set text body (auto-sets Content-Type: text/plain if not already set)
+    #[must_use]
+    pub const fn text(mut self, body: &'a str) -> Self {
+        self.body = Some(ResponseBody::Text(body));
+        self
+    }
+
+    /// Set binary body (caller should set Content-Type via `content_type()`)
+    #[must_use]
+    pub const fn binary(mut self, body: &'a [u8]) -> Self {
+        self.body = Some(ResponseBody::Binary(body));
+        self
+    }
+
+    /// Set empty body
+    #[must_use]
+    pub const fn empty_body(mut self) -> Self {
+        self.body = Some(ResponseBody::Empty);
+        self
+    }
+
+    /// Construct the final `HttpResponse`
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BufferOverflow` if headers buffer is full.
+    #[allow(clippy::unnested_or_patterns)]
+    pub fn build(mut self) -> Result<HttpResponse<'a>, Error> {
+        // Auto-add Content-Type based on body type if not already set
+        if self.auto_content_type {
+            let ct = match &self.body {
+                Some(ResponseBody::Binary(_)) => mime_types::BINARY,
+                Some(ResponseBody::Text(_)) | Some(ResponseBody::Empty) | None => mime_types::TEXT,
+            };
+            self.headers
+                .push(HttpHeader::content_type(ct))
+                .map_err(|_| Error::BufferOverflow)?;
+        }
+
+        Ok(HttpResponse {
+            status_code: self.status,
+            headers: self.headers,
+            body: self.body.unwrap_or(ResponseBody::Empty),
+        })
+    }
+}
+
+impl Default for HttpResponseBuilder<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Push a byte slice into the buffer, returning `BufferOverflow` on failure.
 fn push_slice<const N: usize>(bytes: &mut Vec<u8, N>, data: &[u8]) -> Result<(), Error> {
     bytes
@@ -297,7 +387,7 @@ fn write_decimal_to_buffer<const N: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::header::HttpHeader;
+    use crate::header::{HttpHeader, headers};
     use heapless::Vec;
 
     #[test]
@@ -521,5 +611,118 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_builder_default_ok_empty() {
+        let response = HttpResponseBuilder::new().build().unwrap();
+        assert_eq!(response.status_code, StatusCode::Ok);
+        assert_eq!(response.body, ResponseBody::Empty);
+        assert_eq!(response.get_header("Content-Type"), Some("text/plain"));
+    }
+
+    #[test]
+    fn test_builder_text_success() {
+        let response = HttpResponseBuilder::new()
+            .text(r#"{"status":"ok"}"#)
+            .build()
+            .unwrap();
+        assert_eq!(response.status_code, StatusCode::Ok);
+        assert_eq!(response.body, ResponseBody::Text(r#"{"status":"ok"}"#));
+        assert_eq!(response.get_header("Content-Type"), Some("text/plain"));
+    }
+
+    #[test]
+    fn test_builder_json_with_explicit_content_type() {
+        let response = HttpResponseBuilder::new()
+            .content_type(mime_types::JSON)
+            .unwrap()
+            .text(r#"{"status":"ok"}"#)
+            .build()
+            .unwrap();
+        assert_eq!(response.status_code, StatusCode::Ok);
+        assert_eq!(
+            response.get_header("Content-Type"),
+            Some("application/json")
+        );
+    }
+
+    #[test]
+    fn test_builder_rfc7807_problem_details() {
+        let response = HttpResponseBuilder::new()
+            .status(StatusCode::BadRequest)
+            .content_type(mime_types::PROBLEM_JSON)
+            .unwrap()
+            .text(r#"{"type":"https://example.com/probs/invalid","title":"Invalid parameter"}"#)
+            .build()
+            .unwrap();
+        assert_eq!(response.status_code, StatusCode::BadRequest);
+        assert_eq!(
+            response.get_header("Content-Type"),
+            Some("application/problem+json")
+        );
+    }
+
+    #[test]
+    fn test_builder_text() {
+        let response = HttpResponseBuilder::new()
+            .status(StatusCode::NotFound)
+            .text("Not Found")
+            .build()
+            .unwrap();
+        assert_eq!(response.status_code, StatusCode::NotFound);
+        assert_eq!(response.body, ResponseBody::Text("Not Found"));
+        assert_eq!(response.get_header("Content-Type"), Some("text/plain"));
+    }
+
+    #[test]
+    fn test_builder_binary() {
+        let data = &[0x00, 0x01, 0x02, 0x03];
+        let response = HttpResponseBuilder::new()
+            .content_type(mime_types::BINARY)
+            .unwrap()
+            .binary(data)
+            .build()
+            .unwrap();
+        assert_eq!(response.status_code, StatusCode::Ok);
+        assert_eq!(response.body, ResponseBody::Binary(data));
+        assert_eq!(
+            response.get_header("Content-Type"),
+            Some("application/octet-stream")
+        );
+    }
+
+    #[test]
+    fn test_builder_with_custom_headers() {
+        let response = HttpResponseBuilder::new()
+            .header("X-Custom-Header", "custom-value")
+            .unwrap()
+            .header(headers::CACHE_CONTROL, "no-cache")
+            .unwrap()
+            .text("ok")
+            .build()
+            .unwrap();
+        assert_eq!(response.get_header("X-Custom-Header"), Some("custom-value"));
+        assert_eq!(response.get_header("Cache-Control"), Some("no-cache"));
+    }
+
+    #[test]
+    fn test_builder_status_override() {
+        let response = HttpResponseBuilder::with_status(StatusCode::Created)
+            .text("Created")
+            .build()
+            .unwrap();
+        assert_eq!(response.status_code, StatusCode::Created);
+    }
+
+    #[test]
+    fn test_builder_empty_body() {
+        let response = HttpResponseBuilder::new()
+            .status(StatusCode::NoContent)
+            .empty_body()
+            .build()
+            .unwrap();
+        assert_eq!(response.status_code, StatusCode::NoContent);
+        assert_eq!(response.body, ResponseBody::Empty);
     }
 }


### PR DESCRIPTION
## Summary

Yanks 0.11.8 - convenience constructors were badly designed (json hardcoded to 200, bad_request hardcoded to text/plain).

## New: HttpResponseBuilder

- status(code) - Set HTTP status
- content_type(ct) - Set Content-Type
- header(name, value) - Add custom header
- headers(&[HttpHeader]) - Add multiple headers
- text(body) - Text body (auto Content-Type: text/plain)
- binary(data) - Binary body
- empty_body() - Empty body
- build() - Build HttpResponse

## Also
- Added mime_types::PROBLEM_JSON (RFC 7807)
- Added Eq derive to ResponseBody
- Breaking: removes HttpResponse::json(), text(), not_found(), bad_request()