### PR TITLE
feat: HttpHanlder trait: revert &self to mut &self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-15
+
+### Changed
+
+- `HttpHandler::handle_request` now takes `&mut self` instead of `&self`.
+
 ## [0.11.9] - 2026-06-04
 
 ### Added
@@ -293,7 +299,8 @@ HttpResponseBuilder::new()
 - Support for GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, and CONNECT methods.
 - Configurable client options (retries, timeouts, delays).
 
-[Unreleased]: https://github.com/rttfd/nanofish/compare/v0.11.9...HEAD
+[Unreleased]: https://github.com/rttfd/nanofish/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/rttfd/nanofish/compare/v0.11.9...v0.12.0
 [0.11.9]: https://github.com/rttfd/nanofish/compare/v0.11.8...v0.11.9
 [0.11.8]: https://github.com/rttfd/nanofish/compare/v0.11.7...v0.11.8
 [0.11.7]: https://github.com/rttfd/nanofish/compare/v0.11.6...v0.11.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanofish"
-version = "0.11.9"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.91"
 description = "🐟 A lightweight, `no_std` HTTP client and server for embedded systems built on top of Embassy networking."

--- a/README.md
+++ b/README.md
@@ -33,24 +33,24 @@ Nanofish is designed for embedded systems with limited memory. It provides a sim
 ### Basic HTTP Support (Default)
 ```toml
 [dependencies]
-nanofish = "0.11.9"
+nanofish = "0.12.0"
 ```
 
 ### With TLS/HTTPS Support
 ```toml
 [dependencies]
-nanofish = { version = "0.11.9", features = ["tls"] }
+nanofish = { version = "0.12.0", features = ["tls"] }
 ```
 
 ### With Logging
 ```toml
 # Using defmt (common in embedded/probe-based workflows)
 [dependencies]
-nanofish = { version = "0.11.9", features = ["defmt"] }
+nanofish = { version = "0.12.0", features = ["defmt"] }
 
 # Using the log crate (common in std or defmt-incompatible environments)
 [dependencies]
-nanofish = { version = "0.11.9", features = ["log"] }
+nanofish = { version = "0.12.0", features = ["log"] }
 ```
 
 > **Note:** The `defmt` and `log` features are **mutually exclusive**. Enabling both will produce a compile-time error. If neither is enabled, all logging calls are compiled away to no-ops.
@@ -100,7 +100,7 @@ async fn example(stack: &Stack<'_>) -> Result<(), nanofish::Error> {
     let client = DefaultHttpClient::new(stack);
     let mut response_buffer = [0u8; 8192];
     let headers = [
-        HttpHeader::user_agent("Nanofish/0.11.9"),
+        HttpHeader::user_agent("Nanofish/0.12.0"),
         HttpHeader::content_type(mime_types::JSON),
         HttpHeader::authorization("Bearer token123"),
     ];
@@ -347,7 +347,7 @@ use embassy_net::Stack;
 struct MyHandler;
 
 impl HttpHandler for MyHandler {
-    async fn handle_request(&self, request: &HttpRequest<'_>) -> Result<HttpResponse<'_>, nanofish::Error> {
+    async fn handle_request(&mut self, request: &HttpRequest<'_>) -> Result<HttpResponse<'_>, nanofish::Error> {
         match request.path {
             "/" => Ok(HttpResponse {
                 status_code: StatusCode::Ok,
@@ -387,7 +387,7 @@ use nanofish::{HttpResponseBuilder, HttpHandler, HttpRequest, StatusCode, mime_t
 struct ApiHandler;
 
 impl HttpHandler for ApiHandler {
-    async fn handle_request(&self, request: &HttpRequest<'_>) -> Result<HttpResponse<'_>, nanofish::Error> {
+    async fn handle_request(&mut self, request: &HttpRequest<'_>) -> Result<HttpResponse<'_>, nanofish::Error> {
         match request.path {
             "/api/health" => HttpResponseBuilder::new().json(r#"{"status":"ok"}"#)?.build()?,
             "/"           => HttpResponseBuilder::new()
@@ -419,6 +419,53 @@ impl HttpHandler for ApiHandler {
 | `empty_body()` | Set empty body |
 | `header(name, value)` | Add custom header |
 | `build()` → `Result<HttpResponse>` | Build with header dedup (last wins) |
+
+### Dynamic Responses
+
+```rust,ignore
+use nanofish::{HttpHandler, HttpRequest, HttpResponse, ResponseBody, StatusCode, HttpHeader};
+use heapless::String;
+use core::fmt::Write;
+
+struct DynamicHandler {
+    buffer: String<128>,
+    counter: u32,
+}
+
+impl DynamicHandler {
+    fn new() -> Self {
+        Self { buffer: String::new(), counter: 0 }
+    }
+}
+
+impl HttpHandler for DynamicHandler {
+    async fn handle_request(&mut self, request: &HttpRequest<'_>) -> Result<HttpResponse<'_>, nanofish::Error> {
+        match request.path {
+            "/api/counter" => {
+                self.counter += 1;
+                self.buffer.clear();
+                let _ = write!(self.buffer, "{{\"count\":{}}}", self.counter);
+
+                let mut headers = heapless::Vec::new();
+                let _ = headers.push(HttpHeader::content_type(nanofish::mime_types::JSON));
+
+                Ok(HttpResponse {
+                    status_code: StatusCode::Ok,
+                    headers,
+                    body: ResponseBody::Text(&self.buffer),
+                })
+            }
+            _ => {
+                Ok(HttpResponse {
+                    status_code: StatusCode::NotFound,
+                    headers: heapless::Vec::new(),
+                    body: ResponseBody::Empty,
+                })
+            }
+        }
+    }
+}
+```
 
 ### Server Memory Configuration
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -11,7 +11,10 @@ use heapless::Vec;
 #[allow(async_fn_in_trait)]
 pub trait HttpHandler {
     /// Handle an incoming HTTP request and return a response
-    async fn handle_request(&self, request: &HttpRequest<'_>) -> Result<HttpResponse<'_>, Error>;
+    async fn handle_request(
+        &mut self,
+        request: &HttpRequest<'_>,
+    ) -> Result<HttpResponse<'_>, Error>;
 }
 
 /// A simple handler that serves basic endpoints for testing
@@ -19,7 +22,10 @@ pub trait HttpHandler {
 pub struct SimpleHandler;
 
 impl HttpHandler for SimpleHandler {
-    async fn handle_request(&self, request: &HttpRequest<'_>) -> Result<HttpResponse<'_>, Error> {
+    async fn handle_request(
+        &mut self,
+        request: &HttpRequest<'_>,
+    ) -> Result<HttpResponse<'_>, Error> {
         let mut headers = Vec::new();
         match request.path {
             "/" => {
@@ -59,7 +65,7 @@ mod tests {
     #[test]
     fn test_simple_handler() {
         // Test root path
-        let handler = SimpleHandler;
+        let mut handler = SimpleHandler;
         let request = HttpRequest {
             method: HttpMethod::GET,
             path: "/",
@@ -76,7 +82,7 @@ mod tests {
         );
 
         // Test health endpoint
-        let handler = SimpleHandler;
+        let mut handler = SimpleHandler;
         let request = HttpRequest {
             method: HttpMethod::GET,
             path: "/health",
@@ -90,7 +96,7 @@ mod tests {
         assert_eq!(response.body.as_str(), Some("{\"status\":\"ok\"}"));
 
         // Test 404 path
-        let handler = SimpleHandler;
+        let mut handler = SimpleHandler;
         let request = HttpRequest {
             method: HttpMethod::GET,
             path: "/nonexistent",

--- a/src/server.rs
+++ b/src/server.rs
@@ -91,7 +91,7 @@ impl<
     /// **Important**: This server only accepts plain HTTP connections.
     /// HTTPS/TLS is not supported by the server (only by the client).
     #[expect(clippy::future_not_send)]
-    pub async fn serve<H>(&mut self, stack: Stack<'_>, handler: H) -> !
+    pub async fn serve<H>(&mut self, stack: Stack<'_>, mut handler: H) -> !
     where
         H: HttpHandler,
     {
@@ -139,7 +139,10 @@ impl<
             }
 
             // Parse the request
-            match self.handle_connection(&buf[..total_read], &handler).await {
+            match self
+                .handle_connection(&buf[..total_read], &mut handler)
+                .await
+            {
                 Ok(response_bytes) => {
                     if let Err(e) = socket.write_all(&response_bytes).await {
                         warn!("Failed to write response: {:?}", e);
@@ -227,11 +230,10 @@ impl<
         resp.build_bytes::<MAX_RESPONSE_SIZE>()
     }
 
-    #[expect(clippy::future_not_send)]
     async fn handle_connection<H>(
         &self,
         buffer: &[u8],
-        handler: &H,
+        handler: &mut H,
     ) -> Result<Vec<u8, MAX_RESPONSE_SIZE>, Error>
     where
         H: HttpHandler,


### PR DESCRIPTION
Revert: https://github.com/rttfd/nanofish/commit/d6c8fc7ee9ca94a86be9d8225de5446b510f5daf

Note: RefCell and atomics won't help as responsebody require &'a lifetime, refmut guard will be dropped at the end of func.