### PR TITLE
release/v0.12.1 query helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-06-30
+
+### Added
+
+- Added zero-copy request target and query helpers on `HttpRequest`:
+  - `target()` returns the raw request target.
+  - `route_path()` returns the path without the query string.
+  - `query_string()` returns the raw query string.
+  - `query_pairs()` iterates raw query parameter pairs.
+  - `query()`, `query_first()`, `query_last()`, `query_all()`, `query_indexed()`, and `query_param()` provide URLSearchParams-style access while preserving duplicate keys.
+- Added request convenience helpers: `header()`, `body_str()`, `content_type()`, and `content_length()`.
+- Added `percent_decode()` for explicit, no-allocation query component decoding into a caller-provided buffer.
+- Re-exported `QueryPair`, `QueryPairs`, `QueryValues`, and `percent_decode` from the crate root.
+
+### Notes
+
+- Query helpers return raw, undecoded values by default.
+- Duplicate query keys are preserved.
+- Bracket-style query names such as `f[0]` are treated literally.
+
 ## [0.12.0] - 2026-06-15
 
 ### Changed
@@ -29,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- ❌ **YANKED**: v0.11.8 convenience constructors (`json()`, `text()`, `not_found()`, `bad_request()`) - poorly designed, too opinionated
+- **YANKED**: v0.11.8 convenience constructors (`json()`, `text()`, `not_found()`, `bad_request()`) - poorly designed, too opinionated
   - `json()` was hardcoded to 200 OK (invalid for error responses)
   - `bad_request()` was hardcoded to `text/plain` (invalid for RFC 7807 JSON errors)
   - Not flexible enough for real-world API patterns
@@ -38,8 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Before (removed):**
 ```rust,ignore
-HttpResponse::json(r#"{"status":"ok"}"#)          // ❌ hardcoded 200
-HttpResponse::bad_request("missing parameter")    // ❌ hardcoded text/plain
+HttpResponse::json(r#"{"status":"ok"}"#)          // hardcoded 200
+HttpResponse::bad_request("missing parameter")    // hardcoded text/plain
 ```
 
 **After (builder):**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanofish"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.91"
 description = "🐟 A lightweight, `no_std` HTTP client and server for embedded systems built on top of Embassy networking."
@@ -27,9 +27,11 @@ embassy-net = { version = "0.9.1", features = [
 ] }
 embassy-time = "0.5.1"
 embedded-io-async = "0.7.0"
-embedded-tls = { version = "0.18.0", default-features = false, optional = true }
+embedded-tls = { version = "0.19.0", default-features = false, optional = true }
 heapless = "0.9.3"
 log = { version = "0.4", optional = true }
+# Keep this on 0.6: embedded-tls 0.19 exposes rand_core 0.6 traits in its provider API,
+# so newer rand_core versions are trait-incompatible until embedded-tls upgrades.
 rand_core = { version = "0.6", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -33,24 +33,24 @@ Nanofish is designed for embedded systems with limited memory. It provides a sim
 ### Basic HTTP Support (Default)
 ```toml
 [dependencies]
-nanofish = "0.12.0"
+nanofish = "0.12"
 ```
 
 ### With TLS/HTTPS Support
 ```toml
 [dependencies]
-nanofish = { version = "0.12.0", features = ["tls"] }
+nanofish = { version = "0.12", features = ["tls"] }
 ```
 
 ### With Logging
 ```toml
 # Using defmt (common in embedded/probe-based workflows)
 [dependencies]
-nanofish = { version = "0.12.0", features = ["defmt"] }
+nanofish = { version = "0.12", features = ["defmt"] }
 
 # Using the log crate (common in std or defmt-incompatible environments)
 [dependencies]
-nanofish = { version = "0.12.0", features = ["log"] }
+nanofish = { version = "0.12", features = ["log"] }
 ```
 
 > **Note:** The `defmt` and `log` features are **mutually exclusive**. Enabling both will produce a compile-time error. If neither is enabled, all logging calls are compiled away to no-ops.
@@ -100,7 +100,7 @@ async fn example(stack: &Stack<'_>) -> Result<(), nanofish::Error> {
     let client = DefaultHttpClient::new(stack);
     let mut response_buffer = [0u8; 8192];
     let headers = [
-        HttpHeader::user_agent("Nanofish/0.12.0"),
+        HttpHeader::user_agent("Nanofish/0.12"),
         HttpHeader::content_type(mime_types::JSON),
         HttpHeader::authorization("Bearer token123"),
     ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use handler::{HttpHandler, SimpleHandler};
 pub use header::{HttpHeader, headers, mime_types};
 pub use method::HttpMethod;
 pub use options::HttpClientOptions;
-pub use request::HttpRequest;
+pub use request::{HttpRequest, QueryPair, QueryPairs, QueryValues, percent_decode};
 pub use response::{HttpResponse, ResponseBody};
 pub use server::{DefaultHttpServer, HttpServer, ServerTimeouts, SmallHttpServer};
 pub use status_code::StatusCode;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,17 +1,83 @@
 use crate::{
     error::Error,
-    header::HttpHeader,
+    header::{
+        HttpHeader,
+        headers::{CONTENT_LENGTH, CONTENT_TYPE},
+    },
     method::HttpMethod,
     protocol::{self, DOUBLE_CRLF_LEN, MAX_HEADERS},
 };
 use heapless::Vec;
+
+/// A single raw query parameter pair.
+///
+/// Names and values are returned exactly as they appear in the URL, without
+/// percent-decoding. Duplicate names are preserved and bracket syntax such as
+/// `f[0]` is treated as a literal name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryPair<'a> {
+    /// Raw query parameter name.
+    pub name: &'a str,
+    /// Raw query parameter value, or an empty string for parameters without `=`.
+    pub value: &'a str,
+}
+
+/// Iterator over raw query parameter pairs.
+#[derive(Debug, Clone)]
+pub struct QueryPairs<'a> {
+    remaining: &'a str,
+}
+
+impl<'a> Iterator for QueryPairs<'a> {
+    type Item = QueryPair<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (segment, remaining) = self.remaining.split_once('&').map_or_else(
+                || (self.remaining, ""),
+                |(segment, remaining)| (segment, remaining),
+            );
+            self.remaining = remaining;
+
+            if segment.is_empty() {
+                if self.remaining.is_empty() {
+                    return None;
+                }
+                continue;
+            }
+
+            let (name, value) = segment
+                .split_once('=')
+                .map_or((segment, ""), |(name, value)| (name, value));
+
+            return Some(QueryPair { name, value });
+        }
+    }
+}
+
+/// Iterator over raw values for all query parameters matching a name.
+#[derive(Debug, Clone)]
+pub struct QueryValues<'a, 'n> {
+    pairs: QueryPairs<'a>,
+    name: &'n str,
+}
+
+impl<'a> Iterator for QueryValues<'a, '_> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.pairs
+            .find(|pair| pair.name == self.name)
+            .map(|pair| pair.value)
+    }
+}
 
 /// HTTP request parsed from client
 #[derive(Debug)]
 pub struct HttpRequest<'a> {
     /// HTTP method
     pub method: HttpMethod,
-    /// Request path
+    /// Raw request target from the request line, including any query string
     pub path: &'a str,
     /// HTTP version (e.g., "HTTP/1.1")
     pub version: &'a str,
@@ -22,6 +88,117 @@ pub struct HttpRequest<'a> {
 }
 
 impl<'a> HttpRequest<'a> {
+    /// Get the raw request target from the request line, including any query string.
+    #[must_use]
+    pub const fn target(&self) -> &'a str {
+        self.path
+    }
+
+    /// Get the path without a query string.
+    #[must_use]
+    pub fn route_path(&self) -> &'a str {
+        self.path
+            .split_once('?')
+            .map_or(self.path, |(path, _query)| path)
+    }
+
+    /// Get the raw query string without the leading `?`.
+    #[must_use]
+    pub fn query_string(&self) -> Option<&'a str> {
+        self.path.split_once('?').map(|(_path, query)| query)
+    }
+
+    /// Iterate over raw query parameter pairs.
+    ///
+    /// Duplicate names are preserved. Percent-decoding is not applied.
+    #[must_use]
+    pub fn query_pairs(&self) -> QueryPairs<'a> {
+        QueryPairs {
+            remaining: self.query_string().unwrap_or(""),
+        }
+    }
+
+    /// Return the first raw query parameter value matching `name`.
+    #[must_use]
+    pub fn query(&self, name: &str) -> Option<&'a str> {
+        self.query_first(name)
+    }
+
+    /// Return the first raw query parameter value matching `name`.
+    #[must_use]
+    pub fn query_first(&self, name: &str) -> Option<&'a str> {
+        self.query_pairs()
+            .find(|pair| pair.name == name)
+            .map(|pair| pair.value)
+    }
+
+    /// Return the last raw query parameter value matching `name`.
+    #[must_use]
+    pub fn query_last(&self, name: &str) -> Option<&'a str> {
+        self.query_pairs()
+            .filter(|pair| pair.name == name)
+            .map(|pair| pair.value)
+            .last()
+    }
+
+    /// Iterate over all raw values for query parameters matching `name`.
+    #[must_use]
+    pub fn query_all<'n>(&self, name: &'n str) -> QueryValues<'a, 'n> {
+        QueryValues {
+            pairs: self.query_pairs(),
+            name,
+        }
+    }
+
+    /// Return the first raw query parameter value matching bracket-index syntax.
+    ///
+    /// For example, `query_indexed("f", 0)` matches `f[0]` and returns its
+    /// value. Bracket keys remain literal for [`Self::query`]; this is only a
+    /// convenience helper for applications that use indexed query names.
+    #[must_use]
+    pub fn query_indexed(&self, name: &str, index: usize) -> Option<&'a str> {
+        self.query_pairs()
+            .find(|pair| query_name_matches_index(pair.name, name, index))
+            .map(|pair| pair.value)
+    }
+
+    /// Alias for [`Self::query`].
+    #[must_use]
+    pub fn query_param(&self, name: &str) -> Option<&'a str> {
+        self.query(name)
+    }
+
+    /// Find a request header value by name, case-insensitively.
+    #[must_use]
+    pub fn header(&self, name: &str) -> Option<&'a str> {
+        self.headers
+            .iter()
+            .find(|header| header.name.eq_ignore_ascii_case(name))
+            .map(|header| header.value)
+    }
+
+    /// Get the request body as UTF-8 text.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidResponse` if the body is not valid UTF-8.
+    pub fn body_str(&self) -> Result<&'a str, Error> {
+        core::str::from_utf8(self.body)
+            .map_err(|_| Error::InvalidResponse("Invalid UTF-8 in request body"))
+    }
+
+    /// Get the `Content-Type` header value.
+    #[must_use]
+    pub fn content_type(&self) -> Option<&'a str> {
+        self.header(CONTENT_TYPE)
+    }
+
+    /// Get the `Content-Length` header value parsed as a number.
+    #[must_use]
+    pub fn content_length(&self) -> Option<usize> {
+        self.header(CONTENT_LENGTH)?.parse().ok()
+    }
+
     /// Parse an HTTP request from headers string and body bytes
     ///
     /// # Errors
@@ -98,6 +275,67 @@ impl<'a> TryFrom<&'a [u8]> for HttpRequest<'a> {
     }
 }
 
+/// Percent-decode an `application/x-www-form-urlencoded` query component.
+///
+/// The decoded output is written into `out` and returned as `&str`. `+` is
+/// decoded to a space, and `%HH` sequences are decoded as bytes. The decoded
+/// bytes must be valid UTF-8.
+///
+/// # Errors
+///
+/// Returns `Error::BufferOverflow` when `out` is too small, or
+/// `Error::InvalidResponse` for malformed percent escapes or invalid UTF-8.
+pub fn percent_decode<'a>(input: &str, out: &'a mut [u8]) -> Result<&'a str, Error> {
+    let mut written = 0;
+    let mut bytes = input.as_bytes().iter().copied();
+
+    while let Some(byte) = bytes.next() {
+        let decoded = match byte {
+            b'+' => b' ',
+            b'%' => {
+                let hi = bytes
+                    .next()
+                    .ok_or(Error::InvalidResponse("Incomplete percent escape"))?;
+                let lo = bytes
+                    .next()
+                    .ok_or(Error::InvalidResponse("Incomplete percent escape"))?;
+                (hex_value(hi).ok_or(Error::InvalidResponse("Invalid percent escape"))? << 4)
+                    | hex_value(lo).ok_or(Error::InvalidResponse("Invalid percent escape"))?
+            }
+            byte => byte,
+        };
+
+        let slot = out.get_mut(written).ok_or(Error::BufferOverflow)?;
+        *slot = decoded;
+        written += 1;
+    }
+
+    core::str::from_utf8(&out[..written])
+        .map_err(|_| Error::InvalidResponse("Invalid UTF-8 in percent-decoded value"))
+}
+
+fn query_name_matches_index(query_name: &str, name: &str, index: usize) -> bool {
+    let Some(rest) = query_name.strip_prefix(name) else {
+        return false;
+    };
+    let Some(index_str) = rest
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+    else {
+        return false;
+    };
+    index_str.parse::<usize>().ok() == Some(index)
+}
+
+const fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,6 +354,83 @@ mod tests {
         assert_eq!(request.version, "HTTP/1.1");
         assert_eq!(request.headers.len(), 2);
         assert_eq!(request.body, b"");
+    }
+
+    #[test]
+    fn test_request_query_helpers() {
+        let request_str =
+            "GET /search?q=rust&page=1&flag&a=&a=2 HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        let request = HttpRequest::parse_from(request_str, b"").unwrap();
+
+        assert_eq!(request.target(), "/search?q=rust&page=1&flag&a=&a=2");
+        assert_eq!(request.route_path(), "/search");
+        assert_eq!(request.query_string(), Some("q=rust&page=1&flag&a=&a=2"));
+        assert_eq!(request.query("q"), Some("rust"));
+        assert_eq!(request.query_param("page"), Some("1"));
+        assert_eq!(request.query("flag"), Some(""));
+        assert_eq!(request.query_first("a"), Some(""));
+        assert_eq!(request.query_last("a"), Some("2"));
+        assert_eq!(request.query("missing"), None);
+
+        let mut values = request.query_all("a");
+        assert_eq!(values.next(), Some(""));
+        assert_eq!(values.next(), Some("2"));
+        assert_eq!(values.next(), None);
+    }
+
+    #[test]
+    fn test_request_query_duplicate_and_bracket_keys() {
+        let request_str = "GET /items?a=1&a=2&f[0]=1&f[1]=2 HTTP/1.1\r\n\r\n";
+        let request = HttpRequest::parse_from(request_str, b"").unwrap();
+
+        assert_eq!(request.query_first("a"), Some("1"));
+        assert_eq!(request.query_last("a"), Some("2"));
+        assert_eq!(request.query("f[0]"), Some("1"));
+        assert_eq!(request.query("f[1]"), Some("2"));
+        assert_eq!(request.query("f"), None);
+        assert_eq!(request.query_indexed("f", 0), Some("1"));
+        assert_eq!(request.query_indexed("f", 1), Some("2"));
+        assert_eq!(request.query_indexed("f", 2), None);
+
+        let mut pairs = request.query_pairs();
+        assert_eq!(
+            pairs.next(),
+            Some(QueryPair {
+                name: "a",
+                value: "1"
+            })
+        );
+        assert_eq!(
+            pairs.next(),
+            Some(QueryPair {
+                name: "a",
+                value: "2"
+            })
+        );
+    }
+
+    #[test]
+    fn test_request_header_and_body_helpers() {
+        let request_str =
+            "POST /submit HTTP/1.1\r\ncontent-type: text/plain\r\nContent-Length: 5\r\n\r\n";
+        let request = HttpRequest::parse_from(request_str, b"hello").unwrap();
+
+        assert_eq!(request.header("Content-Type"), Some("text/plain"));
+        assert_eq!(request.content_type(), Some("text/plain"));
+        assert_eq!(request.content_length(), Some(5));
+        assert_eq!(request.body_str().unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_percent_decode_query_component() {
+        let mut out = [0u8; 32];
+        assert_eq!(
+            percent_decode("hello+world%21%2F", &mut out).unwrap(),
+            "hello world!/"
+        );
+        assert!(percent_decode("bad%", &mut out).is_err());
+        assert!(percent_decode("bad%xx", &mut out).is_err());
+        assert!(percent_decode("toolong", &mut [0u8; 3]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
- `target()` returns the raw request target.
- `route_path()` returns the path without the query string.
- `query_string()` returns the raw query string.
- `query_pairs()` iterates raw query parameter pairs.
- `query()`, `query_first()`, `query_last()`, `query_all()`, `query_indexed()`, and `query_param()` provide URLSearchParams-style access while preserving duplicate keys.